### PR TITLE
Purge old, unused squid schemas on a daily schedule

### DIFF
--- a/.env.default
+++ b/.env.default
@@ -13,5 +13,7 @@ MARKETPLACE_API_URL=https://marketplace-api.decentraland.zone/v1
 MARKETPLACE_SERVER_TRADES_API_TOKEN=
 
 # Schema purge job: number of days after which unused squid_* schemas are eligible for cleanup.
-# Leave empty or set to 0 to disable the daily purge. Recommended starting point: 90.
+# Leave empty or set to 0 to disable the purge. Recommended starting point: 90.
 SCHEMA_PURGE_MAX_AGE_DAYS=
+# Schema purge job: how often (in hours) the job re-runs. Defaults to 24 when empty or non-positive.
+SCHEMA_PURGE_INTERVAL_HOURS=

--- a/.env.default
+++ b/.env.default
@@ -11,3 +11,7 @@ DAPPS_PG_COMPONENT_PSQL_CONNECTION_STRING=
 CREDITS_PG_COMPONENT_PSQL_CONNECTION_STRING=
 MARKETPLACE_API_URL=https://marketplace-api.decentraland.zone/v1
 MARKETPLACE_SERVER_TRADES_API_TOKEN=
+
+# Schema purge job: number of days after which unused squid_* schemas are eligible for cleanup.
+# Leave empty or set to 0 to disable the daily purge. Recommended starting point: 90.
+SCHEMA_PURGE_MAX_AGE_DAYS=

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node --trace-warnings --abort-on-uncaught-exception --unhandled-rejections=strict dist/src/index.js",
+    "dry-run:purge": "npm run build && node dist/scripts/dry-run-purge.js",
     "start:watch": "nodemon src/index.ts",
-    "check:code": "eslint src test",
-    "check:prettier": "prettier -c '{src,test}/**/*.{js,ts,json,yml,md}'",
+    "check:code": "eslint src test scripts",
+    "check:prettier": "prettier -c '{src,test,scripts}/**/*.{js,ts,json,yml,md}'",
     "fix:code": "npm run check:code -- --fix",
     "fix:prettier": "npm run check:prettier -- --write",
     "test": "jest --forceExit --detectOpenHandles --coverage --verbose -c jest.config.json",
     "test:watch": "jest --watch --verbose -c jest.config.json",
-    "lint": "eslint src test"
+    "lint": "eslint src test scripts"
   },
   "keywords": [],
   "author": "",

--- a/scripts/dry-run-purge.ts
+++ b/scripts/dry-run-purge.ts
@@ -1,0 +1,105 @@
+/**
+ * Dry-run the schema purge against a live pair of databases and print what
+ * would happen without executing anything destructive.
+ *
+ * Usage:
+ *   npm run dry-run:purge                 # reads SCHEMA_PURGE_MAX_AGE_DAYS from env
+ *   SCHEMA_PURGE_MAX_AGE_DAYS=90 npm run dry-run:purge
+ *
+ * Requires the same env the server does (DAPPS_*, CREDITS_*, AWS_CLUSTER_NAME
+ * and AWS credentials). Reads .env.default + .env from the repo root.
+ */
+import { createDotEnvConfigComponent } from '@well-known-components/env-config-provider'
+import { createLogComponent } from '@well-known-components/logger'
+import { createTracerComponent } from '@well-known-components/tracer-component'
+import { createMetricsComponent } from '@dcl/metrics'
+import { createPgComponent as createBasePgComponent } from '@dcl/pg-component'
+import { createTracedFetcherComponent } from '@dcl/traced-fetch-component'
+import { metricDeclarations } from '../src/metrics'
+import { createPgComponent } from '../src/ports/db/component'
+import { createSubsquidComponent } from '../src/ports/squids/component'
+import { PurgeResult } from '../src/ports/squids/types'
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000
+
+async function main(): Promise<void> {
+  const config = await createDotEnvConfigComponent({ path: ['.env.default', '.env'] })
+
+  const maxAgeDays = await config.getNumber('SCHEMA_PURGE_MAX_AGE_DAYS')
+  if (!maxAgeDays || maxAgeDays <= 0) {
+    console.error('SCHEMA_PURGE_MAX_AGE_DAYS is not set or non-positive — set it to the threshold you want to evaluate and rerun.')
+    process.exit(1)
+  }
+  const olderThanMs = maxAgeDays * ONE_DAY_MS
+
+  const tracer = createTracerComponent()
+  const metrics = await createMetricsComponent(metricDeclarations, { config })
+  const logs = await createLogComponent({ metrics })
+  const fetch = await createTracedFetcherComponent({ tracer })
+
+  const dappsDatabase = await createPgComponent({ config, logs, metrics }, { dbPrefix: 'DAPPS' })
+
+  // Mirrors src/components.ts: credits reuses the DAPPS user / password / host
+  // / port but with its own database name.
+  const creditsDbDatabaseName = await config.requireString('CREDITS_PG_COMPONENT_PSQL_DATABASE')
+  const dbUser = await config.requireString('DAPPS_PG_COMPONENT_PSQL_USER')
+  const dbPort = await config.requireString('DAPPS_PG_COMPONENT_PSQL_PORT')
+  const dbHost = await config.requireString('DAPPS_PG_COMPONENT_PSQL_HOST')
+  const dbPassword = await config.requireString('DAPPS_PG_COMPONENT_PSQL_PASSWORD')
+  const creditsDatabaseUrl = `postgres://${dbUser}:${dbPassword}@${dbHost}:${dbPort}/${creditsDbDatabaseName}`
+  const creditsDatabase = await createBasePgComponent({ config, logs, metrics }, { pool: { connectionString: creditsDatabaseUrl } })
+
+  if (dappsDatabase.start) await dappsDatabase.start()
+  if (creditsDatabase.start) await creditsDatabase.start()
+
+  const squids = await createSubsquidComponent({ fetch, dappsDatabase, creditsDatabase, config, logs })
+
+  console.log('Schema purge — DRY RUN (nothing will be deleted)')
+  console.log(`Threshold: ${maxAgeDays} day(s) (${olderThanMs.toLocaleString()} ms)`)
+  console.log()
+
+  let result: PurgeResult
+  try {
+    result = await squids.purgeOldSchemas({ olderThanMs, dryRun: true })
+  } finally {
+    if (dappsDatabase.stop) await dappsDatabase.stop()
+    if (creditsDatabase.stop) await creditsDatabase.stop()
+  }
+
+  printResult(result)
+  // Explicitly exit so any stray AWS SDK / pg-pool handles don't keep the
+  // process alive.
+  process.exit(0)
+}
+
+function toDays(ms: number): string {
+  return (ms / ONE_DAY_MS).toFixed(1)
+}
+
+function printResult(result: PurgeResult): void {
+  console.log(`Would delete ${result.deleted.length} schema(s):`)
+  if (result.deleted.length === 0) {
+    console.log('  (none)')
+  } else {
+    for (const entry of result.deleted) {
+      console.log(`  ${entry.database.padEnd(8)} ${entry.schema.padEnd(40)} age=${toDays(entry.ageMs)} day(s)`)
+    }
+  }
+
+  console.log()
+  console.log(`Skipped ${result.skipped.length} schema(s) that are old enough but protected:`)
+  if (result.skipped.length === 0) {
+    console.log('  (none)')
+  } else {
+    for (const entry of result.skipped) {
+      console.log(
+        `  ${entry.database.padEnd(8)} ${entry.schema.padEnd(40)} reason=${entry.reason.padEnd(16)} age=${toDays(entry.ageMs)} day(s)`
+      )
+    }
+  }
+}
+
+main().catch(error => {
+  console.error('Dry-run failed:', error instanceof Error ? error.stack || error.message : error)
+  process.exit(1)
+})

--- a/src/components.ts
+++ b/src/components.ts
@@ -79,15 +79,23 @@ export async function initComponents(): Promise<AppComponents> {
     }
   })
 
-  const ONE_DAY_MS = 24 * 60 * 60 * 1000
+  const ONE_HOUR_MS = 60 * 60 * 1000
+  const ONE_DAY_MS = 24 * ONE_HOUR_MS
   const FIVE_MINUTES_MS = 5 * 60 * 1000
+  const DEFAULT_SCHEMA_PURGE_INTERVAL_HOURS = 24
   const schemaPurgeLogger = logs.getLogger('schema-purge-job')
   const schemaPurgeMaxAgeDays = await config.getNumber('SCHEMA_PURGE_MAX_AGE_DAYS')
   const schemaPurgeOlderThanMs = schemaPurgeMaxAgeDays && schemaPurgeMaxAgeDays > 0 ? schemaPurgeMaxAgeDays * ONE_DAY_MS : undefined
+  const configuredIntervalHours = await config.getNumber('SCHEMA_PURGE_INTERVAL_HOURS')
+  const schemaPurgeIntervalHours =
+    configuredIntervalHours && configuredIntervalHours > 0 ? configuredIntervalHours : DEFAULT_SCHEMA_PURGE_INTERVAL_HOURS
+  const schemaPurgeIntervalMs = schemaPurgeIntervalHours * ONE_HOUR_MS
   if (schemaPurgeOlderThanMs === undefined) {
     schemaPurgeLogger.info('SCHEMA_PURGE_MAX_AGE_DAYS not set or non-positive; schema purge job is disabled')
   } else {
-    schemaPurgeLogger.info(`Schema purge enabled: schemas older than ${schemaPurgeMaxAgeDays} day(s) will be candidates`)
+    schemaPurgeLogger.info(
+      `Schema purge enabled: schemas older than ${schemaPurgeMaxAgeDays} day(s), running every ${schemaPurgeIntervalHours} hour(s)`
+    )
   }
   const schemaPurgeJob = createJobComponent(
     { logs },
@@ -99,7 +107,7 @@ export async function initComponents(): Promise<AppComponents> {
         skipped: JSON.stringify(result.skipped)
       })
     },
-    ONE_DAY_MS,
+    schemaPurgeIntervalMs,
     {
       repeat: true,
       // Delay the first run so it doesn't race with the rest of startup.

--- a/src/components.ts
+++ b/src/components.ts
@@ -79,6 +79,34 @@ export async function initComponents(): Promise<AppComponents> {
     }
   })
 
+  const ONE_DAY_MS = 24 * 60 * 60 * 1000
+  const FIVE_MINUTES_MS = 5 * 60 * 1000
+  const schemaPurgeLogger = logs.getLogger('schema-purge-job')
+  const schemaPurgeJob = createJobComponent(
+    { logs },
+    async () => {
+      const maxAgeDays = await config.getNumber('SCHEMA_PURGE_MAX_AGE_DAYS')
+      if (!maxAgeDays || maxAgeDays <= 0) {
+        schemaPurgeLogger.info('SCHEMA_PURGE_MAX_AGE_DAYS not configured; skipping schema purge')
+        return
+      }
+      const result = await squids.purgeOldSchemas({ olderThanMs: maxAgeDays * ONE_DAY_MS })
+      schemaPurgeLogger.info(`Schema purge: deleted ${result.deleted.length}, skipped ${result.skipped.length}`, {
+        deleted: JSON.stringify(result.deleted),
+        skipped: JSON.stringify(result.skipped)
+      })
+    },
+    ONE_DAY_MS,
+    {
+      repeat: true,
+      // Delay the first run so it doesn't race with the rest of startup.
+      startupDelay: FIVE_MINUTES_MS,
+      onError: error => {
+        schemaPurgeLogger.error('Schema purge job failed', { error: error instanceof Error ? error.message : String(error) })
+      }
+    }
+  )
+
   return {
     config,
     logs,
@@ -89,6 +117,7 @@ export async function initComponents(): Promise<AppComponents> {
     metrics,
     squids,
     slack,
-    squidMonitorJob
+    squidMonitorJob,
+    schemaPurgeJob
   }
 }

--- a/src/components.ts
+++ b/src/components.ts
@@ -82,15 +82,18 @@ export async function initComponents(): Promise<AppComponents> {
   const ONE_DAY_MS = 24 * 60 * 60 * 1000
   const FIVE_MINUTES_MS = 5 * 60 * 1000
   const schemaPurgeLogger = logs.getLogger('schema-purge-job')
+  const schemaPurgeMaxAgeDays = await config.getNumber('SCHEMA_PURGE_MAX_AGE_DAYS')
+  const schemaPurgeOlderThanMs = schemaPurgeMaxAgeDays && schemaPurgeMaxAgeDays > 0 ? schemaPurgeMaxAgeDays * ONE_DAY_MS : undefined
+  if (schemaPurgeOlderThanMs === undefined) {
+    schemaPurgeLogger.info('SCHEMA_PURGE_MAX_AGE_DAYS not set or non-positive; schema purge job is disabled')
+  } else {
+    schemaPurgeLogger.info(`Schema purge enabled: schemas older than ${schemaPurgeMaxAgeDays} day(s) will be candidates`)
+  }
   const schemaPurgeJob = createJobComponent(
     { logs },
     async () => {
-      const maxAgeDays = await config.getNumber('SCHEMA_PURGE_MAX_AGE_DAYS')
-      if (!maxAgeDays || maxAgeDays <= 0) {
-        schemaPurgeLogger.info('SCHEMA_PURGE_MAX_AGE_DAYS not configured; skipping schema purge')
-        return
-      }
-      const result = await squids.purgeOldSchemas({ olderThanMs: maxAgeDays * ONE_DAY_MS })
+      if (schemaPurgeOlderThanMs === undefined) return
+      const result = await squids.purgeOldSchemas({ olderThanMs: schemaPurgeOlderThanMs })
       schemaPurgeLogger.info(`Schema purge: deleted ${result.deleted.length}, skipped ${result.skipped.length}`, {
         deleted: JSON.stringify(result.deleted),
         skipped: JSON.stringify(result.skipped)

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -288,8 +288,17 @@ export async function createSubsquidComponent({
     if (existing.length === 0) return { deleted, skipped }
 
     const schemaNames = existing.map(row => row.schema_name)
-    const { rows: ageRows } = await database.query<{ schema: string; max_created_at: Date }>(getSchemaAgesQuery(schemaNames))
-    const schemaAges = new Map(ageRows.map(row => [row.schema, new Date(row.max_created_at).getTime()]))
+    const { rows: ageRows } = await database.query<{ schema: string; max_created_at: Date | null }>(getSchemaAgesQuery(schemaNames))
+    // Defensive: if every `indexers.created_at` for a schema is NULL, `MAX`
+    // also returns NULL. Treating that as epoch (the default of `new Date(null)`)
+    // would make the schema look ~56 years old and trivially pass any
+    // threshold, so we skip it entirely — same safety posture as having no
+    // indexers row at all.
+    const schemaAges = new Map<string, number>()
+    for (const row of ageRows) {
+      if (row.max_created_at == null) continue
+      schemaAges.set(row.schema, new Date(row.max_created_at).getTime())
+    }
 
     const { rows: activeRows } = await database.query<{ schema: string }>(getActivelyPromotedSchemasQuery())
     const activeSchemas = new Set(activeRows.filter(row => row.schema).map(row => row.schema))
@@ -356,17 +365,39 @@ export async function createSubsquidComponent({
    * Minimal ECS lookup for the subset of squid services that currently
    * have a running task. Used as the "don't touch" filter for the purge.
    *
+   * Correctness notes (this list must be complete — anything missing
+   * becomes a deletion candidate):
+   *   - `ListServices` is paginated via `nextToken` so clusters larger
+   *     than one page of 100 services are still fully enumerated.
+   *   - `DescribeServices` accepts at most 10 service ARNs per call
+   *     (AWS hard limit), so we chunk the ARNs into groups of 10.
+   *
    * `list()` could supply the same information, but it additionally
    * describes every task and fetches Prometheus metrics over HTTP per
    * network. That's expensive and unnecessary here, and it also makes
    * the purge tests combinatorially harder to set up.
    */
   async function getRunningSquidServiceNames(): Promise<string[]> {
-    const { serviceArns = [] } = await client.send(new ListServicesCommand({ cluster, maxResults: 100 }))
-    const squidArns = serviceArns.filter(arn => arn.includes('-squid-server'))
+    const DESCRIBE_SERVICES_CHUNK_SIZE = 10
+
+    const squidArns: string[] = []
+    let nextToken: string | undefined
+    do {
+      const response = await client.send(new ListServicesCommand({ cluster, maxResults: 100, nextToken }))
+      for (const arn of response.serviceArns ?? []) {
+        if (arn.includes('-squid-server')) squidArns.push(arn)
+      }
+      nextToken = response.nextToken
+    } while (nextToken)
+
     if (squidArns.length === 0) return []
 
-    const { services = [] } = await client.send(new DescribeServicesCommand({ cluster, services: squidArns }))
+    const services: Array<{ serviceName?: string }> = []
+    for (let i = 0; i < squidArns.length; i += DESCRIBE_SERVICES_CHUNK_SIZE) {
+      const chunk = squidArns.slice(i, i + DESCRIBE_SERVICES_CHUNK_SIZE)
+      const response = await client.send(new DescribeServicesCommand({ cluster, services: chunk }))
+      services.push(...(response.services ?? []))
+    }
 
     const running: string[] = []
     await Promise.all(

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -280,7 +280,7 @@ export async function createSubsquidComponent({
     runningServiceNames: string[],
     olderThanMs: number,
     dryRun: boolean
-  ): Promise<PurgeResult> {
+  ): Promise<Pick<PurgeResult, 'deleted' | 'skipped'>> {
     const deleted: PurgeResult['deleted'] = []
     const skipped: PurgeResult['skipped'] = []
 
@@ -439,14 +439,14 @@ export async function createSubsquidComponent({
       logger.warn('purgeOldSchemas: could not list running services — aborting as a safety measure', {
         error: error instanceof Error ? error.message : String(error)
       })
-      return { deleted: [], skipped: [] }
+      return { dryRun, deleted: [], skipped: [] }
     }
     if (runningServiceNames.length === 0) {
       logger.warn('purgeOldSchemas: no running squid services detected — aborting as a safety measure')
-      return { deleted: [], skipped: [] }
+      return { dryRun, deleted: [], skipped: [] }
     }
 
-    const result: PurgeResult = { deleted: [], skipped: [] }
+    const result: PurgeResult = { dryRun, deleted: [], skipped: [] }
 
     for (const [name, database] of [
       ['dapps', dappsDatabase],

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -247,9 +247,33 @@ export async function createSubsquidComponent({
     }
   }
 
-  // Schema names we create always match this shape; gate every DROP behind the same pattern.
+  /**
+   * Allowed shape for any schema the purge is permitted to drop. Enforced
+   * immediately before each `DROP SCHEMA` so a malformed name that slipped
+   * through earlier filters can never reach the database.
+   */
   const SAFE_SCHEMA_NAME = /^squid_[a-zA-Z0-9_]+$/
 
+  /**
+   * Classifies and purges candidate schemas in a single database. The
+   * caller owns the `runningServiceNames` list so both databases can share
+   * the same ECS snapshot.
+   *
+   * For every `squid_*` schema found:
+   *   1. Look up its age via `MAX(indexers.created_at)`. Schemas without
+   *      an indexers row are silently ignored.
+   *   2. If the age is below `olderThanMs`, do nothing.
+   *   3. Otherwise, classify as one of: `active` (promoted), `running-
+   *      service` (latest deployment of a running ECS service),
+   *      `invalid-name` (failed the safety regex), or a drop candidate.
+   *   4. Drop candidates are DROPped + their indexers rows DELETEd inside
+   *      a per-schema transaction (so a failure can't leave orphan
+   *      history). When `dryRun` is true the drop is not executed but
+   *      the candidate is still reported under `deleted`.
+   *
+   * Per-schema failures are logged and the caller continues with the
+   * next schema; one broken DROP does not abort the whole run.
+   */
   async function purgeSchemasInDatabase(
     databaseName: DatabaseName,
     database: IPgComponent,
@@ -298,23 +322,45 @@ export async function createSubsquidComponent({
 
       if (reason) {
         skipped.push({ ...entry, reason })
+        logger.debug('Skipped schema', { database: databaseName, schema, reason, ageMs })
         continue
       }
 
-      if (!dryRun) {
+      if (dryRun) {
+        logger.info('(dry-run) Would drop schema', { database: databaseName, schema, ageMs })
+        deleted.push(entry)
+        continue
+      }
+
+      try {
         await database.withTransaction(async (pgClient: PoolClient) => {
           await pgClient.query(buildDropSchemaStatement(schema))
           await pgClient.query(getDeleteIndexersBySchemaQuery(schema))
         })
+        logger.info('Dropped schema', { database: databaseName, schema, ageMs })
+        deleted.push(entry)
+      } catch (error) {
+        logger.error('Failed to drop schema', {
+          database: databaseName,
+          schema,
+          ageMs,
+          error: error instanceof Error ? error.message : String(error)
+        })
       }
-      deleted.push(entry)
     }
 
     return { deleted, skipped }
   }
 
-  // Minimal ECS query used by the purge: we only need the names of services that currently have a task.
-  // list() does the same plus describes tasks + fetches metrics, which is too heavy here.
+  /**
+   * Minimal ECS lookup for the subset of squid services that currently
+   * have a running task. Used as the "don't touch" filter for the purge.
+   *
+   * `list()` could supply the same information, but it additionally
+   * describes every task and fetches Prometheus metrics over HTTP per
+   * network. That's expensive and unnecessary here, and it also makes
+   * the purge tests combinatorially harder to set up.
+   */
   async function getRunningSquidServiceNames(): Promise<string[]> {
     const { serviceArns = [] } = await client.send(new ListServicesCommand({ cluster, maxResults: 100 }))
     const squidArns = serviceArns.filter(arn => arn.includes('-squid-server'))
@@ -334,6 +380,20 @@ export async function createSubsquidComponent({
     return running
   }
 
+  /**
+   * Entry point for the schema purge. Enforces the safety rails
+   * documented on `ISquidComponent.purgeOldSchemas` and dispatches to
+   * `purgeSchemasInDatabase` for each of the two databases.
+   *
+   * Logging summary:
+   *   - `warn` — aborting because ECS couldn't be queried or returned no
+   *     running services.
+   *   - `error` — processing a whole database failed (transport-level,
+   *     not a single DROP) or a specific DROP threw.
+   *   - `info` — every drop (or would-drop, in dry-run) with schema,
+   *     database and age; and a final summary line with the totals.
+   *   - `debug` — every skip with the reason.
+   */
   async function purgeOldSchemas({ olderThanMs, dryRun = false }: PurgeOptions): Promise<PurgeResult> {
     if (olderThanMs <= 0) {
       throw new Error(`purgeOldSchemas: olderThanMs must be positive (received ${olderThanMs})`)

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -8,10 +8,12 @@ import {
   UpdateServiceCommand
 } from '@aws-sdk/client-ecs'
 import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
+import { PoolClient } from 'pg'
+import { SQL } from 'sql-template-strings'
 import { IPgComponent } from '@dcl/pg-component'
 import { Network } from '@dcl/schemas'
-import { getActiveSchemaQuery, getPromoteQuery, getSchemaByServiceNameQuery } from './queries'
-import { ISquidComponent, Squid, SquidMetric } from './types'
+import { escapeIdentifier, getActiveSchemaQuery, getPromoteQuery, getSchemaByServiceNameQuery } from './queries'
+import { DatabaseName, ISquidComponent, PurgeOptions, PurgeResult, PurgeSkipReason, Squid, SquidMetric } from './types'
 import { getMetricValue, getProjectNameFromService, getSquidsNetworksMapping } from './utils'
 
 const AWS_REGION = 'us-east-1'
@@ -237,9 +239,147 @@ export async function createSubsquidComponent({
     }
   }
 
+  // Schema names we create always match this shape; gate every DROP behind the same pattern.
+  const SAFE_SCHEMA_NAME = /^squid_[a-zA-Z0-9_]+$/
+
+  async function purgeSchemasInDatabase(
+    databaseName: DatabaseName,
+    database: IPgComponent,
+    runningServiceNames: string[],
+    olderThanMs: number,
+    dryRun: boolean
+  ): Promise<PurgeResult> {
+    const deleted: PurgeResult['deleted'] = []
+    const skipped: PurgeResult['skipped'] = []
+
+    const { rows: existing } = await database.query<{ schema_name: string }>(
+      SQL`SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'squid_%'`
+    )
+    if (existing.length === 0) return { deleted, skipped }
+
+    const schemaNames = existing.map(row => row.schema_name)
+    const { rows: ageRows } = await database.query<{ schema: string; max_created_at: Date }>(
+      SQL`SELECT schema, MAX(created_at) AS max_created_at FROM public.indexers WHERE schema = ANY(${schemaNames}) GROUP BY schema`
+    )
+    const schemaAges = new Map(ageRows.map(row => [row.schema, new Date(row.max_created_at).getTime()]))
+
+    const { rows: activeRows } = await database.query<{ schema: string }>(SQL`SELECT schema FROM public.squids`)
+    const activeSchemas = new Set(activeRows.filter(row => row.schema).map(row => row.schema))
+
+    const runningServiceSchemas = new Set<string>()
+    for (const serviceName of runningServiceNames) {
+      const { rows } = await database.query<{ schema: string }>(
+        SQL`SELECT schema FROM public.indexers WHERE service = ${serviceName} ORDER BY created_at DESC LIMIT 1`
+      )
+      const latest = rows[0]?.schema
+      if (latest) runningServiceSchemas.add(latest)
+    }
+
+    const now = Date.now()
+    for (const schema of schemaNames) {
+      const createdAt = schemaAges.get(schema)
+      if (createdAt === undefined) {
+        // We didn't create it (no indexers row) — leave it alone entirely, don't even report.
+        continue
+      }
+      const ageMs = now - createdAt
+      if (ageMs < olderThanMs) continue
+
+      const entry = { database: databaseName, schema, ageMs }
+      const reason: PurgeSkipReason | undefined = activeSchemas.has(schema)
+        ? 'active'
+        : runningServiceSchemas.has(schema)
+          ? 'running-service'
+          : !SAFE_SCHEMA_NAME.test(schema)
+            ? 'invalid-name'
+            : undefined
+
+      if (reason) {
+        skipped.push({ ...entry, reason })
+        continue
+      }
+
+      if (!dryRun) {
+        await database.withTransaction(async (pgClient: PoolClient) => {
+          await pgClient.query(`DROP SCHEMA ${escapeIdentifier(schema)} CASCADE`)
+          await pgClient.query(SQL`DELETE FROM public.indexers WHERE schema = ${schema}`)
+        })
+      }
+      deleted.push(entry)
+    }
+
+    return { deleted, skipped }
+  }
+
+  // Minimal ECS query used by the purge: we only need the names of services that currently have a task.
+  // list() does the same plus describes tasks + fetches metrics, which is too heavy here.
+  async function getRunningSquidServiceNames(): Promise<string[]> {
+    const { serviceArns = [] } = await client.send(new ListServicesCommand({ cluster, maxResults: 100 }))
+    const squidArns = serviceArns.filter(arn => arn.includes('-squid-server'))
+    if (squidArns.length === 0) return []
+
+    const { services = [] } = await client.send(new DescribeServicesCommand({ cluster, services: squidArns }))
+
+    const running: string[] = []
+    await Promise.all(
+      services.map(async svc => {
+        const serviceName = svc.serviceName
+        if (!serviceName) return
+        const { taskArns = [] } = await client.send(new ListTasksCommand({ cluster, serviceName }))
+        if (taskArns.length > 0) running.push(serviceName)
+      })
+    )
+    return running
+  }
+
+  async function purgeOldSchemas({ olderThanMs, dryRun = false }: PurgeOptions): Promise<PurgeResult> {
+    if (olderThanMs <= 0) {
+      throw new Error(`purgeOldSchemas: olderThanMs must be positive (received ${olderThanMs})`)
+    }
+
+    // Safety rail: if we can't determine what is running, don't delete anything.
+    // An empty ECS response or a transient error must not be interpreted as "nothing is running".
+    let runningServiceNames: string[]
+    try {
+      runningServiceNames = await getRunningSquidServiceNames()
+    } catch (error) {
+      logger.warn('purgeOldSchemas: could not list running services — aborting as a safety measure', {
+        error: error instanceof Error ? error.message : String(error)
+      })
+      return { deleted: [], skipped: [] }
+    }
+    if (runningServiceNames.length === 0) {
+      logger.warn('purgeOldSchemas: no running squid services detected — aborting as a safety measure')
+      return { deleted: [], skipped: [] }
+    }
+
+    const result: PurgeResult = { deleted: [], skipped: [] }
+
+    for (const [name, database] of [
+      ['dapps', dappsDatabase],
+      ['credits', creditsDatabase]
+    ] as const) {
+      try {
+        const partial = await purgeSchemasInDatabase(name, database, runningServiceNames, olderThanMs, dryRun)
+        result.deleted.push(...partial.deleted)
+        result.skipped.push(...partial.skipped)
+      } catch (error) {
+        logger.error(`purgeOldSchemas: failed while processing ${name} database`, {
+          error: error instanceof Error ? error.message : String(error)
+        })
+      }
+    }
+
+    logger.info(
+      `purgeOldSchemas ${dryRun ? '(dry-run) would delete' : 'deleted'} ${result.deleted.length} schema(s); skipped ${result.skipped.length}`
+    )
+    return result
+  }
+
   return {
     list,
     promote,
-    downgrade
+    downgrade,
+    purgeOldSchemas
   }
 }

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -9,10 +9,18 @@ import {
 } from '@aws-sdk/client-ecs'
 import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { PoolClient } from 'pg'
-import { SQL } from 'sql-template-strings'
 import { IPgComponent } from '@dcl/pg-component'
 import { Network } from '@dcl/schemas'
-import { escapeIdentifier, getActiveSchemaQuery, getPromoteQuery, getSchemaByServiceNameQuery } from './queries'
+import {
+  buildDropSchemaStatement,
+  getActiveSchemaQuery,
+  getActivelyPromotedSchemasQuery,
+  getDeleteIndexersBySchemaQuery,
+  getPromoteQuery,
+  getSchemaAgesQuery,
+  getSchemaByServiceNameQuery,
+  getSquidSchemasQuery
+} from './queries'
 import { DatabaseName, ISquidComponent, PurgeOptions, PurgeResult, PurgeSkipReason, Squid, SquidMetric } from './types'
 import { getMetricValue, getProjectNameFromService, getSquidsNetworksMapping } from './utils'
 
@@ -252,25 +260,19 @@ export async function createSubsquidComponent({
     const deleted: PurgeResult['deleted'] = []
     const skipped: PurgeResult['skipped'] = []
 
-    const { rows: existing } = await database.query<{ schema_name: string }>(
-      SQL`SELECT schema_name FROM information_schema.schemata WHERE schema_name LIKE 'squid_%'`
-    )
+    const { rows: existing } = await database.query<{ schema_name: string }>(getSquidSchemasQuery())
     if (existing.length === 0) return { deleted, skipped }
 
     const schemaNames = existing.map(row => row.schema_name)
-    const { rows: ageRows } = await database.query<{ schema: string; max_created_at: Date }>(
-      SQL`SELECT schema, MAX(created_at) AS max_created_at FROM public.indexers WHERE schema = ANY(${schemaNames}) GROUP BY schema`
-    )
+    const { rows: ageRows } = await database.query<{ schema: string; max_created_at: Date }>(getSchemaAgesQuery(schemaNames))
     const schemaAges = new Map(ageRows.map(row => [row.schema, new Date(row.max_created_at).getTime()]))
 
-    const { rows: activeRows } = await database.query<{ schema: string }>(SQL`SELECT schema FROM public.squids`)
+    const { rows: activeRows } = await database.query<{ schema: string }>(getActivelyPromotedSchemasQuery())
     const activeSchemas = new Set(activeRows.filter(row => row.schema).map(row => row.schema))
 
     const runningServiceSchemas = new Set<string>()
     for (const serviceName of runningServiceNames) {
-      const { rows } = await database.query<{ schema: string }>(
-        SQL`SELECT schema FROM public.indexers WHERE service = ${serviceName} ORDER BY created_at DESC LIMIT 1`
-      )
+      const { rows } = await database.query<{ schema: string }>(getSchemaByServiceNameQuery(serviceName))
       const latest = rows[0]?.schema
       if (latest) runningServiceSchemas.add(latest)
     }
@@ -301,8 +303,8 @@ export async function createSubsquidComponent({
 
       if (!dryRun) {
         await database.withTransaction(async (pgClient: PoolClient) => {
-          await pgClient.query(`DROP SCHEMA ${escapeIdentifier(schema)} CASCADE`)
-          await pgClient.query(SQL`DELETE FROM public.indexers WHERE schema = ${schema}`)
+          await pgClient.query(buildDropSchemaStatement(schema))
+          await pgClient.query(getDeleteIndexersBySchemaQuery(schema))
         })
       }
       deleted.push(entry)

--- a/src/ports/squids/queries.ts
+++ b/src/ports/squids/queries.ts
@@ -117,11 +117,17 @@ export const getActiveSchemaQuery = (serviceName: string): SQLStatement => {
 /**
  * Lists every schema in the database whose name starts with `squid_`.
  * Used by the purge job to enumerate candidates before filtering by age and usage.
+ *
+ * Uses a POSIX regex (`~`) rather than `LIKE 'squid_%'` on purpose: in SQL
+ * `LIKE`, `_` is a single-character wildcard, so `'squid_%'` also matches e.g.
+ * `squida_foo`. The `SAFE_SCHEMA_NAME` regex in the component catches those as
+ * `invalid-name`, but narrowing the query itself avoids the wasted round-trip
+ * and removes an easy source of confusion.
  */
 export const getSquidSchemasQuery = (): SQLStatement => SQL`
   SELECT schema_name
   FROM information_schema.schemata
-  WHERE schema_name LIKE 'squid_%';
+  WHERE schema_name ~ '^squid_';
 `
 
 /**

--- a/src/ports/squids/queries.ts
+++ b/src/ports/squids/queries.ts
@@ -113,3 +113,51 @@ export const getActiveSchemaQuery = (serviceName: string): SQLStatement => {
       WHERE name = ${projectName};
   `
 }
+
+/**
+ * Lists every schema in the database whose name starts with `squid_`.
+ * Used by the purge job to enumerate candidates before filtering by age and usage.
+ */
+export const getSquidSchemasQuery = (): SQLStatement => SQL`
+  SELECT schema_name
+  FROM information_schema.schemata
+  WHERE schema_name LIKE 'squid_%';
+`
+
+/**
+ * For the supplied schema names, returns the most recent `indexers.created_at`
+ * per schema. The purge derives a schema's "age" from this value.
+ */
+export const getSchemaAgesQuery = (schemaNames: string[]): SQLStatement => SQL`
+  SELECT schema, MAX(created_at) AS max_created_at
+  FROM public.indexers
+  WHERE schema = ANY(${schemaNames})
+  GROUP BY schema;
+`
+
+/**
+ * Returns the schema currently promoted for every project, i.e. the schemas
+ * actively being read from. These must never be dropped.
+ */
+export const getActivelyPromotedSchemasQuery = (): SQLStatement => SQL`
+  SELECT schema
+  FROM public.squids;
+`
+
+/**
+ * Builds the `DROP SCHEMA <name> CASCADE` statement. Returned as a plain string
+ * (not a SQLStatement) because `<name>` is an identifier, not a parameterisable
+ * value — it is safely escaped with pg's `escapeIdentifier` before being
+ * interpolated. Callers must still gate the schema name with their own
+ * validation before invoking this helper.
+ */
+export const buildDropSchemaStatement = (schemaName: string): string => `DROP SCHEMA ${escapeIdentifier(schemaName)} CASCADE`
+
+/**
+ * Removes every indexers row that references the given schema. Run inside the
+ * same transaction as the corresponding DROP so the deployment history is
+ * consistent with the live schema catalog.
+ */
+export const getDeleteIndexersBySchemaQuery = (schemaName: string): SQLStatement => SQL`
+  DELETE FROM public.indexers WHERE schema = ${schemaName};
+`

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -55,25 +55,32 @@ export type PurgedSchema = {
  * - `running-service`: the schema is the latest deployment for an ECS squid
  *   service that currently has a running task, i.e. it could be promoted
  *   at any moment.
- * - `no-age-info`: no `indexers` row references this schema. We can't
- *   prove we created it and therefore refuse to touch it. In practice this
- *   entry will not appear in the result — such schemas are silently
- *   ignored — but the reason is reserved in case a future change surfaces
- *   them for visibility.
  * - `invalid-name`: the schema name does not match the safety regex
- *   `^squid_[a-zA-Z0-9_]+$`. Reserved for the same reason as
- *   `no-age-info`: a defensive tag that can be surfaced later.
+ *   `^squid_[a-zA-Z0-9_]+$`. A defensive gate applied immediately before
+ *   any `DROP SCHEMA`.
+ *
+ * Schemas without an `indexers` row (unknown age) are silently ignored
+ * and do not appear in the result at all: they are not something the
+ * purge created, and surfacing them would add noise.
  */
-export type PurgeSkipReason = 'active' | 'running-service' | 'no-age-info' | 'invalid-name'
+export type PurgeSkipReason = 'active' | 'running-service' | 'invalid-name'
 
 /**
- * Outcome of a `purgeOldSchemas` run. `deleted` lists what was actually
- * dropped (or would be dropped, when called with `dryRun: true`). `skipped`
- * lists schemas that were old enough but protected; see `PurgeSkipReason`.
- * Failures at DROP time are logged at `error` level and do not appear in
- * either array.
+ * Outcome of a `purgeOldSchemas` run.
+ *
+ * `deleted` lists the schemas the run acted on. When `dryRun` is `false`
+ * they were actually dropped; when `dryRun` is `true` they would have
+ * been dropped but nothing was executed — the `dryRun` flag on the
+ * result exists so downstream consumers (metrics, alerting) can tell
+ * the two apart without extra context.
+ *
+ * `skipped` lists schemas that were old enough but protected; see
+ * `PurgeSkipReason`. Failures at DROP time are logged at `error` level
+ * and do not appear in either array.
  */
 export type PurgeResult = {
+  /** Mirrors the `dryRun` flag the caller passed (default `false`). */
+  dryRun: boolean
   deleted: PurgedSchema[]
   skipped: Array<PurgedSchema & { reason: PurgeSkipReason }>
 }

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -21,8 +21,31 @@ export type Squid = {
   metrics: Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
 }
 
+export type DatabaseName = 'dapps' | 'credits'
+
+export type PurgeOptions = {
+  /** Minimum age (in ms) a schema must have before it is considered for deletion. */
+  olderThanMs: number
+  /** When true, skip the DROP SCHEMA and only report what would happen. */
+  dryRun?: boolean
+}
+
+export type PurgedSchema = {
+  database: DatabaseName
+  schema: string
+  ageMs: number
+}
+
+export type PurgeSkipReason = 'active' | 'running-service' | 'no-age-info' | 'invalid-name'
+
+export type PurgeResult = {
+  deleted: PurgedSchema[]
+  skipped: Array<PurgedSchema & { reason: PurgeSkipReason }>
+}
+
 export type ISquidComponent = {
   list(): Promise<Squid[]>
   downgrade(serviceName: string): Promise<void>
   promote(serviceName: string): Promise<void>
+  purgeOldSchemas(options: PurgeOptions): Promise<PurgeResult>
 }

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -97,6 +97,14 @@ export type ISquidComponent = {
    * - A failure dropping one schema is logged and the caller continues
    *   with the next schema.
    *
+   * Known limitation: the "currently running services" snapshot is taken
+   * once at the start of the sweep; individual `DROP` statements execute
+   * seconds later. A service that restarts mid-sweep (0 running tasks in
+   * the transient window) could have its not-yet-promoted schema fall
+   * off the don't-touch set. The odds of that colliding with the daily
+   * run are very low, and the `active` schema of each project is looked
+   * up separately as a second layer of protection.
+   *
    * @see PurgeOptions, PurgeResult
    */
   purgeOldSchemas(options: PurgeOptions): Promise<PurgeResult>

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -21,6 +21,11 @@ export type Squid = {
   metrics: Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
 }
 
+/**
+ * Identifies which of the two databases the squid component talks to.
+ * Used as an explicit label in purge results and logs so that mixed-DB
+ * outputs remain unambiguous.
+ */
 export type DatabaseName = 'dapps' | 'credits'
 
 export type PurgeOptions = {
@@ -30,14 +35,44 @@ export type PurgeOptions = {
   dryRun?: boolean
 }
 
+/**
+ * A schema that met the age threshold and was either dropped (listed under
+ * `deleted`) or protected from dropping (listed under `skipped`, with a
+ * `reason` tag). Age is the time in ms since the most recent
+ * `indexers.created_at` for that schema.
+ */
 export type PurgedSchema = {
   database: DatabaseName
   schema: string
   ageMs: number
 }
 
+/**
+ * Why an old schema was kept instead of dropped.
+ *
+ * - `active`: the schema is the one currently promoted for some project
+ *   (row in `public.squids`). Dropping it would take down reads.
+ * - `running-service`: the schema is the latest deployment for an ECS squid
+ *   service that currently has a running task, i.e. it could be promoted
+ *   at any moment.
+ * - `no-age-info`: no `indexers` row references this schema. We can't
+ *   prove we created it and therefore refuse to touch it. In practice this
+ *   entry will not appear in the result — such schemas are silently
+ *   ignored — but the reason is reserved in case a future change surfaces
+ *   them for visibility.
+ * - `invalid-name`: the schema name does not match the safety regex
+ *   `^squid_[a-zA-Z0-9_]+$`. Reserved for the same reason as
+ *   `no-age-info`: a defensive tag that can be surfaced later.
+ */
 export type PurgeSkipReason = 'active' | 'running-service' | 'no-age-info' | 'invalid-name'
 
+/**
+ * Outcome of a `purgeOldSchemas` run. `deleted` lists what was actually
+ * dropped (or would be dropped, when called with `dryRun: true`). `skipped`
+ * lists schemas that were old enough but protected; see `PurgeSkipReason`.
+ * Failures at DROP time are logged at `error` level and do not appear in
+ * either array.
+ */
 export type PurgeResult = {
   deleted: PurgedSchema[]
   skipped: Array<PurgedSchema & { reason: PurgeSkipReason }>
@@ -47,5 +82,22 @@ export type ISquidComponent = {
   list(): Promise<Squid[]>
   downgrade(serviceName: string): Promise<void>
   promote(serviceName: string): Promise<void>
+  /**
+   * Sweeps both databases for `squid_*` schemas that are older than
+   * `olderThanMs`, dropping the ones that are not currently promoted and
+   * not the latest deployment of a running ECS service.
+   *
+   * Safety rails:
+   * - Aborts without touching any database if the ECS call for running
+   *   services fails or returns an empty list.
+   * - Every schema name is matched against a strict regex before DROP.
+   * - Drops run inside a per-schema transaction so a failure rolls back
+   *   both the `DROP SCHEMA` and the accompanying `DELETE FROM
+   *   public.indexers`.
+   * - A failure dropping one schema is logged and the caller continues
+   *   with the next schema.
+   *
+   * @see PurgeOptions, PurgeResult
+   */
   purgeOldSchemas(options: PurgeOptions): Promise<PurgeResult>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type BaseComponents = {
   squids: ISquidComponent
   slack: ISlackComponent
   squidMonitorJob: IJobComponent
+  schemaPurgeJob: IJobComponent
 }
 
 // components used in runtime

--- a/test/components.ts
+++ b/test/components.ts
@@ -76,6 +76,7 @@ async function initComponents(): Promise<TestComponents> {
   const slack = createSlackComponent({ logs }, { token: slackToken })
   const monitorSquids = await createSquidMonitor({ config, logs, squids, slack })
   const squidMonitorJob = createJobComponent({ logs }, monitorSquids, 60 * 1000, { repeat: false })
+  const schemaPurgeJob = createJobComponent({ logs }, () => Promise.resolve(), 24 * 60 * 60 * 1000, { repeat: false })
 
   return {
     config,
@@ -87,6 +88,7 @@ async function initComponents(): Promise<TestComponents> {
     metrics,
     squids,
     slack,
-    squidMonitorJob
+    squidMonitorJob,
+    schemaPurgeJob
   }
 }

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -225,6 +225,16 @@ describe('createSubsquidComponent', () => {
       oldDate = new Date(Date.now() - 10 * ONE_DAY_MS)
     })
 
+    describe('when olderThanMs is zero or negative', () => {
+      it('should throw before performing any ECS or database call', async () => {
+        const subsquid = await buildComponent()
+        await expect(subsquid.purgeOldSchemas({ olderThanMs: 0 })).rejects.toThrow('olderThanMs must be positive')
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(ecsClientMock.send).not.toHaveBeenCalled()
+        expect(dappsMock.query).not.toHaveBeenCalled()
+      })
+    })
+
     describe('when ECS reports no running squid services', () => {
       let result: PurgeResult
 
@@ -346,9 +356,98 @@ describe('createSubsquidComponent', () => {
           expect(result.deleted[0].schema).toBe('squid_old_orphan')
         })
 
+        it('should mark the result as dry-run so downstream consumers can tell', () => {
+          expect(result.dryRun).toBe(true)
+        })
+
         it('should not open any transaction on the dapps database', () => {
           expect(dappsMock.withTransaction).not.toHaveBeenCalled()
         })
+      })
+
+      describe('and the DROP for the orphan schema throws', () => {
+        let result: PurgeResult
+
+        beforeEach(async () => {
+          dappsMock.withTransaction.mockImplementationOnce(() => {
+            throw new Error('connection lost')
+          })
+
+          const subsquid = await buildComponent()
+          result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+        })
+
+        it('should not list the failed schema under deleted', () => {
+          expect(result.deleted).toHaveLength(0)
+        })
+
+        it('should still have attempted the transaction', () => {
+          expect(dappsMock.withTransaction).toHaveBeenCalledTimes(1)
+        })
+
+        it('should keep the active and running-service skip reasons for the other candidates', () => {
+          expect(result.skipped).toContainEqual(expect.objectContaining({ schema: 'squid_active', reason: 'active' }))
+          expect(result.skipped).toContainEqual(expect.objectContaining({ schema: 'squid_running_latest', reason: 'running-service' }))
+        })
+      })
+    })
+
+    describe('when a candidate schema name fails the safety regex', () => {
+      let result: PurgeResult
+
+      beforeEach(async () => {
+        ;(ecsClientMock.send as jest.Mock)
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:ecs:us-east-1::service/cluster/marketplace-squid-server-a'] })
+          .mockResolvedValueOnce({ services: [{ serviceName: 'marketplace-squid-server-a' }] })
+          .mockResolvedValueOnce({ taskArns: ['task-arn'] })
+
+        dappsMock.query = makeQueryRouter({
+          schemata: [{ schema_name: 'squid_old-with-hyphen' }], // hyphen is disallowed by SAFE_SCHEMA_NAME
+          indexerAges: [{ schema: 'squid_old-with-hyphen', max_created_at: oldDate }]
+        })
+
+        const subsquid = await buildComponent()
+        result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+      })
+
+      it('should report the schema as skipped with reason "invalid-name"', () => {
+        expect(result.skipped).toContainEqual(expect.objectContaining({ schema: 'squid_old-with-hyphen', reason: 'invalid-name' }))
+      })
+
+      it('should not delete the schema', () => {
+        expect(result.deleted).toHaveLength(0)
+      })
+
+      it('should not open any transaction on the dapps database', () => {
+        expect(dappsMock.withTransaction).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the credits database also holds an old orphan schema', () => {
+      let result: PurgeResult
+
+      beforeEach(async () => {
+        ;(ecsClientMock.send as jest.Mock)
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:ecs:us-east-1::service/cluster/marketplace-squid-server-a'] })
+          .mockResolvedValueOnce({ services: [{ serviceName: 'marketplace-squid-server-a' }] })
+          .mockResolvedValueOnce({ taskArns: ['task-arn'] })
+
+        creditsMock.query = makeQueryRouter({
+          schemata: [{ schema_name: 'squid_credits_orphan' }],
+          indexerAges: [{ schema: 'squid_credits_orphan', max_created_at: oldDate }]
+        })
+
+        const subsquid = await buildComponent()
+        result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+      })
+
+      it('should delete the orphan schema from the credits database', () => {
+        expect(result.deleted).toContainEqual(expect.objectContaining({ database: 'credits', schema: 'squid_credits_orphan' }))
+      })
+
+      it('should open the transaction on the credits database, not dapps', () => {
+        expect(creditsMock.withTransaction).toHaveBeenCalledTimes(1)
+        expect(dappsMock.withTransaction).not.toHaveBeenCalled()
       })
     })
   })

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -3,6 +3,7 @@ import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known
 import { IPgComponent } from '@dcl/pg-component'
 import { createSubsquidComponent } from '../../src/ports/squids/component'
 import { getPromoteQuery } from '../../src/ports/squids/queries'
+import { PurgeResult, Squid } from '../../src/ports/squids/types'
 
 type MockDatabase = {
   query: jest.Mock
@@ -42,121 +43,133 @@ describe('createSubsquidComponent', () => {
     ;(UpdateServiceCommand as unknown as jest.Mock).mockImplementation(UpdateServiceCommandMock)
   })
 
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   describe('list', () => {
-    beforeEach(() => {
-      const services = [{ serviceName: 'test-squid-service' }]
-      const tasks = [
-        {
-          version: 1,
-          createdAt: new Date(),
-          healthStatus: 'HEALTHY',
-          lastStatus: 'RUNNING',
-          attachments: [
-            {
-              type: 'ElasticNetworkInterface',
-              details: [{ name: 'privateIPv4Address', value: '127.0.0.1' }]
-            }
-          ]
-        }
-      ]
+    describe('when there is one running squid service with metrics on Ethereum', () => {
+      let result: Squid[]
 
-      ;(ecsClientMock.send as jest.Mock)
-        .mockResolvedValueOnce({ serviceArns: ['arn:aws:squid-service'] }) // ListServicesCommand
-        .mockResolvedValueOnce({ services }) // DescribeServicesCommand
-        .mockResolvedValueOnce({ taskArns: ['arn:aws:ecs:task/test'] }) // ListTasksCommand
-        .mockResolvedValueOnce({ tasks }) // DescribeTasksCommand
-      ;(fetchMock.fetch as jest.Mock).mockResolvedValue({
-        text: jest.fn().mockResolvedValue(`
-          sqd_processor_last_block 1000
-          sqd_processor_sync_eta_seconds 120
-        `)
+      beforeEach(async () => {
+        const services = [{ serviceName: 'test-squid-service' }]
+        const tasks = [
+          {
+            version: 1,
+            createdAt: new Date(),
+            healthStatus: 'HEALTHY',
+            lastStatus: 'RUNNING',
+            attachments: [
+              {
+                type: 'ElasticNetworkInterface',
+                details: [{ name: 'privateIPv4Address', value: '127.0.0.1' }]
+              }
+            ]
+          }
+        ]
+
+        ;(ecsClientMock.send as jest.Mock)
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:squid-service'] })
+          .mockResolvedValueOnce({ services })
+          .mockResolvedValueOnce({ taskArns: ['arn:aws:ecs:task/test'] })
+          .mockResolvedValueOnce({ tasks })
+        ;(fetchMock.fetch as jest.Mock).mockResolvedValue({
+          text: jest.fn().mockResolvedValue(`
+            sqd_processor_last_block 1000
+            sqd_processor_sync_eta_seconds 120
+          `)
+        })
+        ;(dappsDatabaseMock.query as jest.Mock)
+          .mockResolvedValueOnce({ rows: [{ schema: 'test-schema' }] })
+          .mockResolvedValueOnce({ rows: [{ schema: 'active-schema' }] })
+
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+        result = await subsquid.list()
       })
-      ;(dappsDatabaseMock.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ schema: 'test-schema' }] }) // getSchemaByServiceNameQuery
-        .mockResolvedValueOnce({ rows: [{ schema: 'active-schema' }] }) // getActiveSchemaQuery
-    })
 
-    it('should list squid services and fetch metrics in parallel', async () => {
-      const subsquid = await createSubsquidComponent({
-        fetch: fetchMock,
-        dappsDatabase: dappsDatabaseMock,
-        creditsDatabase: creditsDatabaseMock,
-        config: configMock,
-        logs: logsMock
+      it('should return the squid populated with its schema info and Ethereum metrics', () => {
+        expect(result).toHaveLength(1)
+        expect(result[0]).toMatchObject({
+          name: 'test-squid-service',
+          schema_name: 'test-schema',
+          project_active_schema: 'active-schema'
+        })
+        expect(result[0].metrics?.ETHEREUM?.sqd_processor_last_block).toBe(1000)
+        expect(result[0].metrics?.ETHEREUM?.sqd_processor_sync_eta_seconds).toBe(120)
       })
-
-      const result = await subsquid.list()
-
-      expect(result).toHaveLength(1)
-      expect(result[0].name).toBe('test-squid-service')
-      expect(result[0].schema_name).toBe('test-schema')
-      expect(result[0].project_active_schema).toBe('active-schema')
-      expect(result[0].metrics?.ETHEREUM?.sqd_processor_last_block).toBe(1000)
-      expect(result[0].metrics?.ETHEREUM?.sqd_processor_sync_eta_seconds).toBe(120)
     })
   })
 
   describe('promote', () => {
-    beforeEach(() => {
-      ;(getPromoteQuery as jest.Mock).mockReturnValue('PROMOTE QUERY')
-      ;(dappsDatabaseMock.query as jest.Mock).mockResolvedValue({})
-    })
+    describe('when promoting a dapps-backed squid service', () => {
+      beforeEach(async () => {
+        ;(getPromoteQuery as jest.Mock).mockReturnValue('PROMOTE QUERY')
+        ;(dappsDatabaseMock.query as jest.Mock).mockResolvedValue({})
 
-    it('should execute the promote query', async () => {
-      const subsquid = await createSubsquidComponent({
-        fetch: fetchMock,
-        dappsDatabase: dappsDatabaseMock,
-        creditsDatabase: creditsDatabaseMock,
-        config: configMock,
-        logs: logsMock
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+        await subsquid.promote('test-service-name')
       })
 
-      await subsquid.promote('test-service-name')
+      it('should build the promote query from the service name with a squid_ schema and the test project', () => {
+        expect(getPromoteQuery).toHaveBeenCalledWith('test-service-name', expect.stringMatching(/^squid_/), expect.stringMatching(/^test/))
+      })
 
-      expect(getPromoteQuery).toHaveBeenCalledWith(
-        'test-service-name',
-        expect.stringMatching(/^squid_/), // Ensures schema name starts with "squid_"
-        expect.stringMatching(/^test/) // Ensures project name starts with "test"
-      )
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(dappsDatabaseMock.query).toHaveBeenCalledWith('PROMOTE QUERY')
+      it('should execute the promote query against the dapps database', () => {
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(dappsDatabaseMock.query).toHaveBeenCalledWith('PROMOTE QUERY')
+      })
     })
   })
 
   describe('downgrade', () => {
-    beforeEach(() => {
-      ;(ecsClientMock.send as jest.Mock).mockResolvedValue({})
-    })
+    describe('when downgrading a squid service', () => {
+      beforeEach(async () => {
+        ;(ecsClientMock.send as jest.Mock).mockResolvedValue({})
 
-    it('should set desiredCount to 0', async () => {
-      const subsquid = await createSubsquidComponent({
-        fetch: fetchMock,
-        dappsDatabase: dappsDatabaseMock,
-        creditsDatabase: creditsDatabaseMock,
-        config: configMock,
-        logs: logsMock
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+        await subsquid.downgrade('test-service-name')
       })
 
-      await subsquid.downgrade('test-service-name')
-
-      expect(UpdateServiceCommandMock).toHaveBeenCalledWith({
-        cluster: 'test-cluster',
-        service: 'test-service-name',
-        desiredCount: 0
+      it('should build an UpdateService command with desiredCount 0 on the configured cluster', () => {
+        expect(UpdateServiceCommandMock).toHaveBeenCalledWith({
+          cluster: 'test-cluster',
+          service: 'test-service-name',
+          desiredCount: 0
+        })
       })
 
-      // eslint-disable-next-line @typescript-eslint/unbound-method
-      expect(ecsClientMock.send).toHaveBeenCalledWith(expect.any(UpdateServiceCommand))
+      it('should send the UpdateService command to ECS', () => {
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(ecsClientMock.send).toHaveBeenCalledWith(expect.any(UpdateServiceCommand))
+      })
     })
   })
 
   describe('purgeOldSchemas', () => {
     const ONE_DAY_MS = 24 * 60 * 60 * 1000
     const OLDER_THAN_MS = 2 * ONE_DAY_MS
-    const OLD_DATE = new Date(Date.now() - 10 * ONE_DAY_MS)
 
     let dappsMock: MockDatabase
     let creditsMock: MockDatabase
+    let oldDate: Date
 
     function buildDatabaseMock(): MockDatabase {
       const txClient = { query: jest.fn() }
@@ -185,16 +198,6 @@ describe('createSubsquidComponent', () => {
       })
     }
 
-    beforeEach(() => {
-      dappsMock = buildDatabaseMock()
-      creditsMock = buildDatabaseMock()
-      dappsDatabaseMock = dappsMock as unknown as IPgComponent
-      creditsDatabaseMock = creditsMock as unknown as IPgComponent
-      // Default: both DBs empty so unscoped tests don't accidentally delete anything.
-      dappsMock.query = makeQueryRouter({})
-      creditsMock.query = makeQueryRouter({})
-    })
-
     async function buildComponent() {
       return createSubsquidComponent({
         fetch: fetchMock,
@@ -205,41 +208,62 @@ describe('createSubsquidComponent', () => {
       })
     }
 
+    beforeEach(() => {
+      dappsMock = buildDatabaseMock()
+      creditsMock = buildDatabaseMock()
+      dappsDatabaseMock = dappsMock as unknown as IPgComponent
+      creditsDatabaseMock = creditsMock as unknown as IPgComponent
+      dappsMock.query = makeQueryRouter({})
+      creditsMock.query = makeQueryRouter({})
+      oldDate = new Date(Date.now() - 10 * ONE_DAY_MS)
+    })
+
     describe('when ECS reports no running squid services', () => {
-      beforeEach(() => {
+      let result: PurgeResult
+
+      beforeEach(async () => {
         ;(ecsClientMock.send as jest.Mock).mockImplementation(async (cmd: unknown) => {
           if (cmd instanceof ListServicesCommand) return { serviceArns: [] }
           return {}
         })
+
+        const subsquid = await buildComponent()
+        result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
       })
 
-      it('should abort without querying the databases', async () => {
-        const subsquid = await buildComponent()
-
-        const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
-
+      it('should return an empty deleted and skipped result', () => {
         expect(result).toEqual({ deleted: [], skipped: [] })
+      })
+
+      it('should not query the dapps database', () => {
         expect(dappsMock.query).not.toHaveBeenCalled()
+      })
+
+      it('should not query the credits database', () => {
         expect(creditsMock.query).not.toHaveBeenCalled()
       })
     })
 
-    describe('when getRunningSquidServiceNames throws', () => {
-      beforeEach(() => {
+    describe('when the ECS call to list running services throws', () => {
+      let result: PurgeResult
+
+      beforeEach(async () => {
         ;(ecsClientMock.send as jest.Mock).mockRejectedValue(new Error('ECS down'))
+
+        const subsquid = await buildComponent()
+        result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
       })
 
-      it('should abort without deleting anything', async () => {
-        const subsquid = await buildComponent()
-
-        const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
-
+      it('should return an empty deleted and skipped result', () => {
         expect(result).toEqual({ deleted: [], skipped: [] })
+      })
+
+      it('should not open a transaction on the dapps database', () => {
         expect(dappsMock.withTransaction).not.toHaveBeenCalled()
       })
     })
 
-    describe('when a service is running and databases hold schemas of different kinds', () => {
+    describe('when a service is running and the dapps database holds a mix of schema kinds', () => {
       beforeEach(() => {
         ;(ecsClientMock.send as jest.Mock).mockImplementation(async (cmd: unknown) => {
           if (cmd instanceof ListServicesCommand)
@@ -251,53 +275,77 @@ describe('createSubsquidComponent', () => {
 
         dappsMock.query = makeQueryRouter({
           schemata: [
-            { schema_name: 'squid_old_orphan' }, // should be deleted
-            { schema_name: 'squid_active' }, // promoted — skipped
-            { schema_name: 'squid_running_latest' }, // latest for running service — skipped
+            { schema_name: 'squid_old_orphan' }, // old, not in use, not running — should be deleted
+            { schema_name: 'squid_active' }, // currently promoted — skipped as 'active'
+            { schema_name: 'squid_running_latest' }, // latest for a running service — skipped as 'running-service'
             { schema_name: 'squid_no_history' } // no indexers row — silently ignored
           ],
           indexerAges: [
-            { schema: 'squid_old_orphan', max_created_at: OLD_DATE },
-            { schema: 'squid_active', max_created_at: OLD_DATE },
-            { schema: 'squid_running_latest', max_created_at: OLD_DATE }
+            { schema: 'squid_old_orphan', max_created_at: oldDate },
+            { schema: 'squid_active', max_created_at: oldDate },
+            { schema: 'squid_running_latest', max_created_at: oldDate }
           ],
           activeSchemas: [{ schema: 'squid_active' }],
           latestBySvc: { 'marketplace-squid-server-a': 'squid_running_latest' }
         })
       })
 
-      it('should delete only the old orphan and report the others as skipped', async () => {
-        const subsquid = await buildComponent()
+      describe('and dryRun is false', () => {
+        let result: PurgeResult
 
-        const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+        beforeEach(async () => {
+          const subsquid = await buildComponent()
+          result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+        })
 
-        expect(result.deleted).toHaveLength(1)
-        expect(result.deleted[0]).toMatchObject({ database: 'dapps', schema: 'squid_old_orphan' })
-        expect(result.skipped).toEqual(
-          expect.arrayContaining([
-            expect.objectContaining({ schema: 'squid_active', reason: 'active' }),
-            expect.objectContaining({ schema: 'squid_running_latest', reason: 'running-service' })
-          ])
-        )
-        expect(result.skipped).toHaveLength(2)
-        expect(dappsMock.withTransaction).toHaveBeenCalledTimes(1)
+        it('should delete only the old orphan schema', () => {
+          expect(result.deleted).toHaveLength(1)
+          expect(result.deleted[0]).toMatchObject({ database: 'dapps', schema: 'squid_old_orphan' })
+        })
 
-        expect(dappsMock.txClient.query).toHaveBeenNthCalledWith(1, expect.stringContaining('DROP SCHEMA'))
+        it('should report the actively promoted schema as skipped with reason "active"', () => {
+          expect(result.skipped).toContainEqual(expect.objectContaining({ schema: 'squid_active', reason: 'active' }))
+        })
 
-        expect(dappsMock.txClient.query).toHaveBeenNthCalledWith(
-          2,
-          expect.objectContaining({ text: expect.stringContaining('DELETE FROM public.indexers') })
-        )
+        it('should report the running-service schema as skipped with reason "running-service"', () => {
+          expect(result.skipped).toContainEqual(expect.objectContaining({ schema: 'squid_running_latest', reason: 'running-service' }))
+        })
+
+        it('should silently ignore the schema without any indexers history', () => {
+          expect(result.skipped).toHaveLength(2)
+          expect(result.skipped).not.toContainEqual(expect.objectContaining({ schema: 'squid_no_history' }))
+        })
+
+        it('should open exactly one transaction on the dapps database', () => {
+          expect(dappsMock.withTransaction).toHaveBeenCalledTimes(1)
+        })
+
+        it('should DROP the orphan schema first inside the transaction', () => {
+          expect(dappsMock.txClient.query).toHaveBeenNthCalledWith(1, expect.stringContaining('DROP SCHEMA'))
+        })
+
+        it('should DELETE the orphan schema rows from public.indexers after the DROP', () => {
+          expect(dappsMock.txClient.query).toHaveBeenNthCalledWith(
+            2,
+            expect.objectContaining({ text: expect.stringContaining('DELETE FROM public.indexers') })
+          )
+        })
       })
 
       describe('and dryRun is true', () => {
-        it('should report the target as deleted without executing any DROP', async () => {
+        let result: PurgeResult
+
+        beforeEach(async () => {
           const subsquid = await buildComponent()
+          result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS, dryRun: true })
+        })
 
-          const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS, dryRun: true })
-
+        it('should still report the orphan schema as a deletion candidate', () => {
           expect(result.deleted).toHaveLength(1)
           expect(result.deleted[0].schema).toBe('squid_old_orphan')
+        })
+
+        it('should not open any transaction on the dapps database', () => {
           expect(dappsMock.withTransaction).not.toHaveBeenCalled()
         })
       })

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -38,7 +38,8 @@ describe('createSubsquidComponent', () => {
       getLogger: jest.fn().mockReturnValue({
         info: jest.fn(),
         error: jest.fn(),
-        warn: jest.fn()
+        warn: jest.fn(),
+        debug: jest.fn()
       })
     }
 

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -236,7 +236,7 @@ describe('createSubsquidComponent', () => {
       })
 
       it('should return an empty deleted and skipped result', () => {
-        expect(result).toEqual({ deleted: [], skipped: [] })
+        expect(result).toEqual({ dryRun: false, deleted: [], skipped: [] })
       })
 
       it('should not query the dapps database', () => {
@@ -259,7 +259,7 @@ describe('createSubsquidComponent', () => {
       })
 
       it('should return an empty deleted and skipped result', () => {
-        expect(result).toEqual({ deleted: [], skipped: [] })
+        expect(result).toEqual({ dryRun: false, deleted: [], skipped: [] })
       })
 
       it('should not open a transaction on the dapps database', () => {

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -1,4 +1,4 @@
-import { DescribeServicesCommand, ECSClient, ListServicesCommand, ListTasksCommand, UpdateServiceCommand } from '@aws-sdk/client-ecs'
+import { ECSClient, UpdateServiceCommand } from '@aws-sdk/client-ecs'
 import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { IPgComponent } from '@dcl/pg-component'
 import { createSubsquidComponent } from '../../src/ports/squids/component'
@@ -12,7 +12,13 @@ type MockDatabase = {
 }
 
 jest.mock('@aws-sdk/client-ecs')
-jest.mock('../../src/ports/squids/queries')
+jest.mock('../../src/ports/squids/queries', () => {
+  const actual = jest.requireActual<typeof import('../../src/ports/squids/queries')>('../../src/ports/squids/queries')
+  // Only getPromoteQuery is mocked (the promote test stubs its return value);
+  // everything else keeps its real implementation so the purge router can route
+  // based on the actual SQL text.
+  return { ...actual, getPromoteQuery: jest.fn() }
+})
 
 describe('createSubsquidComponent', () => {
   let fetchMock: IFetchComponent
@@ -188,7 +194,7 @@ describe('createSubsquidComponent', () => {
         if (text.includes('information_schema.schemata')) return { rows: responses.schemata ?? [] }
         if (text.includes('MAX(created_at)')) return { rows: responses.indexerAges ?? [] }
         if (text.includes('FROM public.squids')) return { rows: responses.activeSchemas ?? [] }
-        if (text.includes('FROM public.indexers WHERE service')) {
+        if (text.includes('public.indexers') && text.includes('WHERE service')) {
           const values = (sql as { values: unknown[] }).values ?? []
           const serviceName = String(values[0] ?? '')
           const schema = responses.latestBySvc?.[serviceName]
@@ -222,10 +228,7 @@ describe('createSubsquidComponent', () => {
       let result: PurgeResult
 
       beforeEach(async () => {
-        ;(ecsClientMock.send as jest.Mock).mockImplementation(async (cmd: unknown) => {
-          if (cmd instanceof ListServicesCommand) return { serviceArns: [] }
-          return {}
-        })
+        ;(ecsClientMock.send as jest.Mock).mockResolvedValueOnce({ serviceArns: [] })
 
         const subsquid = await buildComponent()
         result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
@@ -248,7 +251,7 @@ describe('createSubsquidComponent', () => {
       let result: PurgeResult
 
       beforeEach(async () => {
-        ;(ecsClientMock.send as jest.Mock).mockRejectedValue(new Error('ECS down'))
+        ;(ecsClientMock.send as jest.Mock).mockRejectedValueOnce(new Error('ECS down'))
 
         const subsquid = await buildComponent()
         result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
@@ -265,13 +268,10 @@ describe('createSubsquidComponent', () => {
 
     describe('when a service is running and the dapps database holds a mix of schema kinds', () => {
       beforeEach(() => {
-        ;(ecsClientMock.send as jest.Mock).mockImplementation(async (cmd: unknown) => {
-          if (cmd instanceof ListServicesCommand)
-            return { serviceArns: ['arn:aws:ecs:us-east-1::service/cluster/marketplace-squid-server-a'] }
-          if (cmd instanceof DescribeServicesCommand) return { services: [{ serviceName: 'marketplace-squid-server-a' }] }
-          if (cmd instanceof ListTasksCommand) return { taskArns: ['task-arn'] }
-          return {}
-        })
+        ;(ecsClientMock.send as jest.Mock)
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:ecs:us-east-1::service/cluster/marketplace-squid-server-a'] }) // ListServicesCommand
+          .mockResolvedValueOnce({ services: [{ serviceName: 'marketplace-squid-server-a' }] }) // DescribeServicesCommand
+          .mockResolvedValueOnce({ taskArns: ['task-arn'] }) // ListTasksCommand
 
         dappsMock.query = makeQueryRouter({
           schemata: [

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -1,8 +1,14 @@
-import { ECSClient, UpdateServiceCommand } from '@aws-sdk/client-ecs'
+import { DescribeServicesCommand, ECSClient, ListServicesCommand, ListTasksCommand, UpdateServiceCommand } from '@aws-sdk/client-ecs'
 import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { IPgComponent } from '@dcl/pg-component'
 import { createSubsquidComponent } from '../../src/ports/squids/component'
 import { getPromoteQuery } from '../../src/ports/squids/queries'
+
+type MockDatabase = {
+  query: jest.Mock
+  withTransaction: jest.Mock
+  txClient: { query: jest.Mock }
+}
 
 jest.mock('@aws-sdk/client-ecs')
 jest.mock('../../src/ports/squids/queries')
@@ -141,6 +147,160 @@ describe('createSubsquidComponent', () => {
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(ecsClientMock.send).toHaveBeenCalledWith(expect.any(UpdateServiceCommand))
+    })
+  })
+
+  describe('purgeOldSchemas', () => {
+    const ONE_DAY_MS = 24 * 60 * 60 * 1000
+    const OLDER_THAN_MS = 2 * ONE_DAY_MS
+    const OLD_DATE = new Date(Date.now() - 10 * ONE_DAY_MS)
+
+    let dappsMock: MockDatabase
+    let creditsMock: MockDatabase
+
+    function buildDatabaseMock(): MockDatabase {
+      const txClient = { query: jest.fn() }
+      const withTransaction = jest.fn().mockImplementation(async (cb: (c: { query: jest.Mock }) => Promise<unknown>) => cb(txClient))
+      return { query: jest.fn(), withTransaction, txClient }
+    }
+
+    function makeQueryRouter(responses: {
+      schemata?: Array<{ schema_name: string }>
+      indexerAges?: Array<{ schema: string; max_created_at: Date }>
+      activeSchemas?: Array<{ schema: string }>
+      latestBySvc?: Record<string, string>
+    }): jest.Mock {
+      return jest.fn().mockImplementation(async (sql: unknown) => {
+        const text = typeof sql === 'string' ? sql : (sql as { text: string }).text
+        if (text.includes('information_schema.schemata')) return { rows: responses.schemata ?? [] }
+        if (text.includes('MAX(created_at)')) return { rows: responses.indexerAges ?? [] }
+        if (text.includes('FROM public.squids')) return { rows: responses.activeSchemas ?? [] }
+        if (text.includes('FROM public.indexers WHERE service')) {
+          const values = (sql as { values: unknown[] }).values ?? []
+          const serviceName = String(values[0] ?? '')
+          const schema = responses.latestBySvc?.[serviceName]
+          return { rows: schema ? [{ schema }] : [] }
+        }
+        return { rows: [] }
+      })
+    }
+
+    beforeEach(() => {
+      dappsMock = buildDatabaseMock()
+      creditsMock = buildDatabaseMock()
+      dappsDatabaseMock = dappsMock as unknown as IPgComponent
+      creditsDatabaseMock = creditsMock as unknown as IPgComponent
+      // Default: both DBs empty so unscoped tests don't accidentally delete anything.
+      dappsMock.query = makeQueryRouter({})
+      creditsMock.query = makeQueryRouter({})
+    })
+
+    async function buildComponent() {
+      return createSubsquidComponent({
+        fetch: fetchMock,
+        dappsDatabase: dappsDatabaseMock,
+        creditsDatabase: creditsDatabaseMock,
+        config: configMock,
+        logs: logsMock
+      })
+    }
+
+    describe('when ECS reports no running squid services', () => {
+      beforeEach(() => {
+        ;(ecsClientMock.send as jest.Mock).mockImplementation(async (cmd: unknown) => {
+          if (cmd instanceof ListServicesCommand) return { serviceArns: [] }
+          return {}
+        })
+      })
+
+      it('should abort without querying the databases', async () => {
+        const subsquid = await buildComponent()
+
+        const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+
+        expect(result).toEqual({ deleted: [], skipped: [] })
+        expect(dappsMock.query).not.toHaveBeenCalled()
+        expect(creditsMock.query).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when getRunningSquidServiceNames throws', () => {
+      beforeEach(() => {
+        ;(ecsClientMock.send as jest.Mock).mockRejectedValue(new Error('ECS down'))
+      })
+
+      it('should abort without deleting anything', async () => {
+        const subsquid = await buildComponent()
+
+        const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+
+        expect(result).toEqual({ deleted: [], skipped: [] })
+        expect(dappsMock.withTransaction).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when a service is running and databases hold schemas of different kinds', () => {
+      beforeEach(() => {
+        ;(ecsClientMock.send as jest.Mock).mockImplementation(async (cmd: unknown) => {
+          if (cmd instanceof ListServicesCommand)
+            return { serviceArns: ['arn:aws:ecs:us-east-1::service/cluster/marketplace-squid-server-a'] }
+          if (cmd instanceof DescribeServicesCommand) return { services: [{ serviceName: 'marketplace-squid-server-a' }] }
+          if (cmd instanceof ListTasksCommand) return { taskArns: ['task-arn'] }
+          return {}
+        })
+
+        dappsMock.query = makeQueryRouter({
+          schemata: [
+            { schema_name: 'squid_old_orphan' }, // should be deleted
+            { schema_name: 'squid_active' }, // promoted — skipped
+            { schema_name: 'squid_running_latest' }, // latest for running service — skipped
+            { schema_name: 'squid_no_history' } // no indexers row — silently ignored
+          ],
+          indexerAges: [
+            { schema: 'squid_old_orphan', max_created_at: OLD_DATE },
+            { schema: 'squid_active', max_created_at: OLD_DATE },
+            { schema: 'squid_running_latest', max_created_at: OLD_DATE }
+          ],
+          activeSchemas: [{ schema: 'squid_active' }],
+          latestBySvc: { 'marketplace-squid-server-a': 'squid_running_latest' }
+        })
+      })
+
+      it('should delete only the old orphan and report the others as skipped', async () => {
+        const subsquid = await buildComponent()
+
+        const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS })
+
+        expect(result.deleted).toHaveLength(1)
+        expect(result.deleted[0]).toMatchObject({ database: 'dapps', schema: 'squid_old_orphan' })
+        expect(result.skipped).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ schema: 'squid_active', reason: 'active' }),
+            expect.objectContaining({ schema: 'squid_running_latest', reason: 'running-service' })
+          ])
+        )
+        expect(result.skipped).toHaveLength(2)
+        expect(dappsMock.withTransaction).toHaveBeenCalledTimes(1)
+
+        expect(dappsMock.txClient.query).toHaveBeenNthCalledWith(1, expect.stringContaining('DROP SCHEMA'))
+
+        expect(dappsMock.txClient.query).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({ text: expect.stringContaining('DELETE FROM public.indexers') })
+        )
+      })
+
+      describe('and dryRun is true', () => {
+        it('should report the target as deleted without executing any DROP', async () => {
+          const subsquid = await buildComponent()
+
+          const result = await subsquid.purgeOldSchemas({ olderThanMs: OLDER_THAN_MS, dryRun: true })
+
+          expect(result.deleted).toHaveLength(1)
+          expect(result.deleted[0].schema).toBe('squid_old_orphan')
+          expect(dappsMock.withTransaction).not.toHaveBeenCalled()
+        })
+      })
     })
   })
 })

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -38,7 +38,8 @@ describe('Squid Monitor', () => {
     squidsMock = {
       list: jest.fn().mockResolvedValue([]),
       downgrade: jest.fn(),
-      promote: jest.fn()
+      promote: jest.fn(),
+      purgeOldSchemas: jest.fn()
     }
 
     // Mock the Slack component

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -15,7 +15,7 @@ type SendMessageCall = [{ text: string; blocks?: SlackMessageBlock[] }]
 
 describe('Squid Monitor', () => {
   let logsMock: ILoggerComponent
-  let loggerMock: { info: jest.Mock; error: jest.Mock; warn: jest.Mock }
+  let loggerMock: { info: jest.Mock; error: jest.Mock; warn: jest.Mock; debug: jest.Mock }
   let squidsMock: ISquidComponent
   let configMock: IConfigComponent
   let slackComponentMock: ISlackComponent
@@ -27,7 +27,8 @@ describe('Squid Monitor', () => {
     loggerMock = {
       info: jest.fn(),
       error: jest.fn(),
-      warn: jest.fn()
+      warn: jest.fn(),
+      debug: jest.fn()
     }
     logsMock = {
       getLogger: jest.fn().mockReturnValue(loggerMock)

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -11,20 +11,19 @@ import {
 } from '../../src/ports/job/squid-monitor'
 import { ISquidComponent, Squid, SquidMetric } from '../../src/ports/squids/types'
 
+type SendMessageCall = [{ text: string; blocks?: SlackMessageBlock[] }]
+
 describe('Squid Monitor', () => {
   let logsMock: ILoggerComponent
   let loggerMock: { info: jest.Mock; error: jest.Mock; warn: jest.Mock }
   let squidsMock: ISquidComponent
   let configMock: IConfigComponent
   let slackComponentMock: ISlackComponent
-  let mockSquids: Squid[]
   let monitorSquids: () => Promise<void>
 
   beforeEach(() => {
-    // Clear throttle state before each test
     clearNoMetricsThrottleState()
 
-    // Mock the logger
     loggerMock = {
       info: jest.fn(),
       error: jest.fn(),
@@ -34,7 +33,6 @@ describe('Squid Monitor', () => {
       getLogger: jest.fn().mockReturnValue(loggerMock)
     }
 
-    // Mock the squids component
     squidsMock = {
       list: jest.fn().mockResolvedValue([]),
       downgrade: jest.fn(),
@@ -42,12 +40,10 @@ describe('Squid Monitor', () => {
       purgeOldSchemas: jest.fn()
     }
 
-    // Mock the Slack component
     slackComponentMock = {
       sendMessage: jest.fn()
     }
 
-    // Mock the config component
     configMock = {
       getString: jest.fn().mockImplementation((key: string) => {
         if (key === 'ENV') {
@@ -57,300 +53,135 @@ describe('Squid Monitor', () => {
       })
     } as unknown as IConfigComponent
 
-    // Create test squids
-    mockSquids = [
-      {
-        name: 'Squid Without ETA',
-        service_name: 'squid-without-eta',
-        schema_name: 'active-schema',
-        project_active_schema: 'active-schema',
-        created_at: undefined,
-        health_status: undefined,
-        service_status: undefined,
-        version: 1,
-        metrics: {
-          [Network.ETHEREUM]: {
-            sqd_processor_sync_eta_seconds: null as unknown as number,
-            sqd_processor_last_block: 1000,
-            sqd_processor_chain_height: 1010,
-            sqd_processor_mapping_blocks_per_second: 5
-          },
-          [Network.MATIC]: {
-            sqd_processor_sync_eta_seconds: undefined as unknown as number,
-            sqd_processor_last_block: 2000,
-            sqd_processor_chain_height: 2010,
-            sqd_processor_mapping_blocks_per_second: 7
-          }
-        }
-      },
-      {
-        name: 'Squid Without Metrics',
-        service_name: 'squid-without-metrics',
-        schema_name: 'active-schema',
-        project_active_schema: 'active-schema',
-        created_at: undefined,
-        health_status: undefined,
-        service_status: undefined,
-        version: 1,
-        metrics: {
-          [Network.ETHEREUM]: undefined,
-          [Network.MATIC]: undefined
-        } as unknown as Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
-      },
-      {
-        name: 'Out of Sync Squid',
-        service_name: 'out-of-sync-squid',
-        schema_name: 'active-schema',
-        project_active_schema: 'active-schema',
-        created_at: undefined,
-        health_status: undefined,
-        service_status: undefined,
-        version: 1,
-        metrics: {
-          [Network.ETHEREUM]: {
-            sqd_processor_sync_eta_seconds: ETA_CONSIDERED_OUT_OF_SYNC + 5,
-            sqd_processor_last_block: 1000,
-            sqd_processor_chain_height: 1020,
-            sqd_processor_mapping_blocks_per_second: 8
-          },
-          [Network.MATIC]: {
-            sqd_processor_sync_eta_seconds: 5,
-            sqd_processor_last_block: 2000,
-            sqd_processor_chain_height: 2005,
-            sqd_processor_mapping_blocks_per_second: 12
-          }
-        }
-      },
-      {
-        name: 'Synchronized Squid',
-        service_name: 'synchronized-squid',
-        schema_name: 'active-schema',
-        project_active_schema: 'active-schema',
-        created_at: undefined,
-        health_status: undefined,
-        service_status: undefined,
-        version: 1,
-        metrics: {
-          [Network.ETHEREUM]: {
-            sqd_processor_sync_eta_seconds: 5,
-            sqd_processor_last_block: 1000,
-            sqd_processor_chain_height: 1005,
-            sqd_processor_mapping_blocks_per_second: 10
-          },
-          [Network.MATIC]: {
-            sqd_processor_sync_eta_seconds: 3,
-            sqd_processor_last_block: 2000,
-            sqd_processor_chain_height: 2002,
-            sqd_processor_mapping_blocks_per_second: 15
-          }
-        }
-      }
-    ]
-
-    // Configure development environment for tests
     process.env.ENV = 'prd'
     process.env.USE_MOCK_SQUIDS = 'false'
     delete process.env.FORCE_ETA_UNAVAILABLE
   })
 
   afterEach(() => {
-    // Clean all mocks
     jest.clearAllMocks()
   })
 
   describe('monitorSquids', () => {
     beforeEach(async () => {
-      const components = { logs: logsMock, squids: squidsMock, config: configMock, slack: slackComponentMock }
-      monitorSquids = await createSquidMonitor(components)
+      monitorSquids = await createSquidMonitor({ logs: logsMock, squids: squidsMock, config: configMock, slack: slackComponentMock })
     })
 
-    describe('when squids have undefined or null ETA', () => {
-      beforeEach(() => {
-        // Configure the mock to return a squid with unavailable ETA
-        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[0]])
-      })
+    describe('when the active squid has undefined or null ETA on both networks', () => {
+      let sendMessageCalls: SendMessageCall[]
 
-      it('should send alerts for each network with unavailable ETA', async () => {
-        // Execute the monitoring function
+      beforeEach(async () => {
+        const squidWithoutEta: Squid = {
+          name: 'Squid Without ETA',
+          service_name: 'squid-without-eta',
+          schema_name: 'active-schema',
+          project_active_schema: 'active-schema',
+          created_at: undefined,
+          health_status: undefined,
+          service_status: undefined,
+          version: 1,
+          metrics: {
+            [Network.ETHEREUM]: {
+              sqd_processor_sync_eta_seconds: null as unknown as number,
+              sqd_processor_last_block: 1000,
+              sqd_processor_chain_height: 1010,
+              sqd_processor_mapping_blocks_per_second: 5
+            },
+            [Network.MATIC]: {
+              sqd_processor_sync_eta_seconds: undefined as unknown as number,
+              sqd_processor_last_block: 2000,
+              sqd_processor_chain_height: 2010,
+              sqd_processor_mapping_blocks_per_second: 7
+            }
+          }
+        }
+        squidsMock.list = jest.fn().mockResolvedValue([squidWithoutEta])
+
         await monitorSquids()
-
-        // Verify that sendMessage was called for the squid without ETA (twice, once for each network)
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(slackComponentMock.sendMessage).toHaveBeenCalledTimes(2)
-
-        // Verify that the messages contain the correct information for unavailable ETA
-        const calls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
-
-        // Verify that at least one of the messages is for unavailable ETA on Ethereum
-        const etaUnavailableEthereumCall = calls.find(
-          (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
-            call[0].text && call[0].text.includes('Cannot read ETA') && call[0].text.includes('ETHEREUM')
-        )
-        expect(etaUnavailableEthereumCall).toBeTruthy()
-
-        // Verify that at least one of the messages is for unavailable ETA on Matic
-        const etaUnavailableMaticCall = calls.find(
-          (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
-            call[0].text && call[0].text.includes('Cannot read ETA') && call[0].text.includes('MATIC')
-        )
-        expect(etaUnavailableMaticCall).toBeTruthy()
-      })
-    })
-
-    describe('when squids have ETA > ETA_CONSIDERED_OUT_OF_SYNC seconds', () => {
-      beforeEach(() => {
-        // Configure the mock to return an out of sync squid
-        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[2]])
+        sendMessageCalls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
       })
 
-      it('should send alerts for networks with ETA > ETA_CONSIDERED_OUT_OF_SYNC seconds', async () => {
-        // Execute the monitoring function
-        await monitorSquids()
+      it('should send one alert per network', () => {
+        expect(sendMessageCalls).toHaveLength(2)
+      })
 
-        // Verify that sendMessage was called for the out of sync squid (only on Ethereum)
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(slackComponentMock.sendMessage).toHaveBeenCalledTimes(1)
+      it('should send a "cannot read ETA" alert for Ethereum', () => {
+        const call = sendMessageCalls.find(c => c[0].text?.includes('Cannot read ETA') && c[0].text?.includes('ETHEREUM'))
+        expect(call).toBeTruthy()
+      })
 
-        // Verify that the messages contain the correct information for desynchronization
-        const calls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
-
-        // Verify that the message is for desynchronization on Ethereum
-        const desyncCall = calls.find(
-          (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
-            call[0].text && call[0].text.includes('out of sync') && call[0].text.includes('ETHEREUM')
-        )
-        expect(desyncCall).toBeTruthy()
-
-        // Verify that the message contains the correct information
-        expect(
-          desyncCall &&
-            desyncCall[0].blocks?.some(
-              (block: SlackMessageBlock) =>
-                block.type === 'section' &&
-                block.fields &&
-                block.fields.some(field => field.text.includes('Current ETA') && field.text.includes('5 seconds'))
-            )
-        ).toBeTruthy()
+      it('should send a "cannot read ETA" alert for Matic', () => {
+        const call = sendMessageCalls.find(c => c[0].text?.includes('Cannot read ETA') && c[0].text?.includes('MATIC'))
+        expect(call).toBeTruthy()
       })
     })
 
-    describe('when squids have ETA <= 10 seconds', () => {
-      beforeEach(() => {
-        // Configure the mock to return a synchronized squid
-        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[3]])
+    describe('when the active squid is out of sync on Ethereum only', () => {
+      let sendMessageCalls: SendMessageCall[]
+
+      beforeEach(async () => {
+        const outOfSyncSquid: Squid = {
+          name: 'Out of Sync Squid',
+          service_name: 'out-of-sync-squid',
+          schema_name: 'active-schema',
+          project_active_schema: 'active-schema',
+          created_at: undefined,
+          health_status: undefined,
+          service_status: undefined,
+          version: 1,
+          metrics: {
+            [Network.ETHEREUM]: {
+              sqd_processor_sync_eta_seconds: ETA_CONSIDERED_OUT_OF_SYNC + 5,
+              sqd_processor_last_block: 1000,
+              sqd_processor_chain_height: 1020,
+              sqd_processor_mapping_blocks_per_second: 8
+            },
+            [Network.MATIC]: {
+              sqd_processor_sync_eta_seconds: 5,
+              sqd_processor_last_block: 2000,
+              sqd_processor_chain_height: 2005,
+              sqd_processor_mapping_blocks_per_second: 12
+            }
+          }
+        }
+        squidsMock.list = jest.fn().mockResolvedValue([outOfSyncSquid])
+
+        await monitorSquids()
+        sendMessageCalls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
       })
 
-      it('should not send any alerts', async () => {
-        // Execute the monitoring function
-        await monitorSquids()
+      it('should send exactly one alert', () => {
+        expect(sendMessageCalls).toHaveLength(1)
+      })
 
-        // Verify that no messages were sent
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(slackComponentMock.sendMessage).not.toHaveBeenCalled()
+      it('should send a desync alert for Ethereum', () => {
+        const call = sendMessageCalls.find(c => c[0].text?.includes('out of sync') && c[0].text?.includes('ETHEREUM'))
+        expect(call).toBeTruthy()
+      })
+
+      it('should include the current ETA value in the desync alert', () => {
+        const call = sendMessageCalls.find(c => c[0].text?.includes('out of sync') && c[0].text?.includes('ETHEREUM'))
+        const hasCurrentEta = call?.[0].blocks?.some(
+          block =>
+            block.type === 'section' &&
+            block.fields !== undefined &&
+            block.fields.some(field => field.text.includes('Current ETA') && field.text.includes('5 seconds'))
+        )
+        expect(hasCurrentEta).toBe(true)
       })
     })
 
-    describe('when squids have no metrics - throttling behavior', () => {
-      beforeEach(() => {
-        // Configure the mock to return a squid without metrics
-        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[1]]) // Squid Without Metrics
-      })
-
-      it('should not send alert on first detection of no metrics', async () => {
-        // Execute the monitoring function
-        await monitorSquids()
-
-        // Verify that no slack message was sent
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(slackComponentMock.sendMessage).not.toHaveBeenCalled()
-
-        // Verify that the issue was logged
-        expect(loggerMock.warn).toHaveBeenCalledWith('No metrics found for squid squid-without-metrics on network ETHEREUM')
-        expect(loggerMock.warn).toHaveBeenCalledWith('No metrics found for squid squid-without-metrics on network MATIC')
-
-        // Verify that the first detection was logged
-        expect(loggerMock.info).toHaveBeenCalledWith(
-          'First detection of no metrics for squid-without-metrics on ETHEREUM. Will send alert after 5 minutes.'
-        )
-        expect(loggerMock.info).toHaveBeenCalledWith(
-          'First detection of no metrics for squid-without-metrics on MATIC. Will send alert after 5 minutes.'
-        )
-
-        // Verify that the state is stored
-        expect(noMetricsFirstDetected.size).toBe(2)
-        expect(noMetricsFirstDetected.has('squid-without-metrics-ETHEREUM-no-metrics')).toBe(true)
-        expect(noMetricsFirstDetected.has('squid-without-metrics-MATIC-no-metrics')).toBe(true)
-      })
-
-      it('should send alert after 5 minutes have passed', async () => {
-        const fiveMinutesAgo = Date.now() - FIVE_MINUTES - 1000 // Add extra 1 second to ensure we're past the threshold
-
-        // Simulate that the issue was first detected 5+ minutes ago
-        noMetricsFirstDetected.set('squid-without-metrics-ETHEREUM-no-metrics', fiveMinutesAgo)
-        noMetricsFirstDetected.set('squid-without-metrics-MATIC-no-metrics', fiveMinutesAgo)
-
-        // Execute the monitoring function
-        await monitorSquids()
-
-        // Verify that slack messages were sent for both networks
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(slackComponentMock.sendMessage).toHaveBeenCalledTimes(2)
-
-        // Verify message content includes duration
-        const calls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
-
-        // Check that both messages are for no metrics
-        const noMetricsCallEthereum = calls.find(
-          (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
-            call[0].text && call[0].text.includes('No metrics found') && call[0].text.includes('ETHEREUM')
-        )
-        expect(noMetricsCallEthereum).toBeTruthy()
-
-        const noMetricsCallMatic = calls.find(
-          (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
-            call[0].text && call[0].text.includes('No metrics found') && call[0].text.includes('MATIC')
-        )
-        expect(noMetricsCallMatic).toBeTruthy()
-
-        // Verify that the messages contain duration information
-        expect(
-          noMetricsCallEthereum &&
-            noMetricsCallEthereum[0].blocks?.some(
-              (block: SlackMessageBlock) =>
-                block.type === 'section' && block.text && block.text.text.includes('Issue duration:') && block.text.text.includes('minutes')
-            )
-        ).toBeTruthy()
-      })
-
-      it('should not send multiple alerts within 5 minutes after first alert', async () => {
-        const fiveMinutesAgo = Date.now() - FIVE_MINUTES - 1000
-
-        // Simulate that the issue was first detected 5+ minutes ago and alert was already sent
-        noMetricsFirstDetected.set('squid-without-metrics-ETHEREUM-no-metrics', fiveMinutesAgo)
-        noMetricsFirstDetected.set('squid-without-metrics-MATIC-no-metrics', fiveMinutesAgo)
-
-        // Execute monitoring (this should send alerts and reset timestamps)
-        await monitorSquids()
-
-        // Clear the mock call history
-        ;(slackComponentMock.sendMessage as jest.Mock).mockClear()
-
-        // Execute monitoring again immediately (should not send alerts)
-        await monitorSquids()
-
-        // Verify that no additional slack messages were sent
-        // eslint-disable-next-line @typescript-eslint/unbound-method
-        expect(slackComponentMock.sendMessage).not.toHaveBeenCalled()
-      })
-
-      it('should clear throttle state when metrics are recovered', async () => {
-        // First, establish that no metrics were detected
-        noMetricsFirstDetected.set('squid-without-metrics-ETHEREUM-no-metrics', Date.now())
-        noMetricsFirstDetected.set('squid-without-metrics-MATIC-no-metrics', Date.now())
-
-        // Now provide a squid with metrics
-        const squidWithRecoveredMetrics = {
-          ...mockSquids[1],
+    describe('when every active squid has an ETA at or below the threshold', () => {
+      beforeEach(async () => {
+        const synchronizedSquid: Squid = {
+          name: 'Synchronized Squid',
+          service_name: 'synchronized-squid',
+          schema_name: 'active-schema',
+          project_active_schema: 'active-schema',
+          created_at: undefined,
+          health_status: undefined,
+          service_status: undefined,
+          version: 1,
           metrics: {
             [Network.ETHEREUM]: {
               sqd_processor_sync_eta_seconds: 5,
@@ -366,18 +197,184 @@ describe('Squid Monitor', () => {
             }
           }
         }
+        squidsMock.list = jest.fn().mockResolvedValue([synchronizedSquid])
 
-        squidsMock.list = jest.fn().mockResolvedValue([squidWithRecoveredMetrics])
-
-        // Execute the monitoring function
         await monitorSquids()
+      })
 
-        // Verify that the throttle state was cleared
+      it('should not send any slack alerts', () => {
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(slackComponentMock.sendMessage).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when the active squid has no metrics on either network', () => {
+      const serviceName = 'squid-without-metrics'
+      const ethereumKey = `${serviceName}-ETHEREUM-no-metrics`
+      const maticKey = `${serviceName}-MATIC-no-metrics`
+
+      let squidWithoutMetrics: Squid
+
+      beforeEach(() => {
+        squidWithoutMetrics = {
+          name: 'Squid Without Metrics',
+          service_name: serviceName,
+          schema_name: 'active-schema',
+          project_active_schema: 'active-schema',
+          created_at: undefined,
+          health_status: undefined,
+          service_status: undefined,
+          version: 1,
+          metrics: {
+            [Network.ETHEREUM]: undefined,
+            [Network.MATIC]: undefined
+          } as unknown as Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
+        }
+        squidsMock.list = jest.fn().mockResolvedValue([squidWithoutMetrics])
+      })
+
+      describe('and it is the first detection', () => {
+        beforeEach(async () => {
+          await monitorSquids()
+        })
+
+        it('should not send any slack alerts', () => {
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          expect(slackComponentMock.sendMessage).not.toHaveBeenCalled()
+        })
+
+        it('should warn that metrics are missing on Ethereum', () => {
+          expect(loggerMock.warn).toHaveBeenCalledWith(`No metrics found for squid ${serviceName} on network ETHEREUM`)
+        })
+
+        it('should warn that metrics are missing on Matic', () => {
+          expect(loggerMock.warn).toHaveBeenCalledWith(`No metrics found for squid ${serviceName} on network MATIC`)
+        })
+
+        it('should log that it will send an alert after 5 minutes for Ethereum', () => {
+          expect(loggerMock.info).toHaveBeenCalledWith(
+            `First detection of no metrics for ${serviceName} on ETHEREUM. Will send alert after 5 minutes.`
+          )
+        })
+
+        it('should log that it will send an alert after 5 minutes for Matic', () => {
+          expect(loggerMock.info).toHaveBeenCalledWith(
+            `First detection of no metrics for ${serviceName} on MATIC. Will send alert after 5 minutes.`
+          )
+        })
+
+        it('should record the first-detection timestamp for both networks', () => {
+          expect(noMetricsFirstDetected.size).toBe(2)
+          expect(noMetricsFirstDetected.has(ethereumKey)).toBe(true)
+          expect(noMetricsFirstDetected.has(maticKey)).toBe(true)
+        })
+      })
+
+      describe('and more than 5 minutes have passed since the first detection', () => {
+        let sendMessageCalls: SendMessageCall[]
+
+        beforeEach(async () => {
+          const fiveMinutesAgo = Date.now() - FIVE_MINUTES - 1000
+          noMetricsFirstDetected.set(ethereumKey, fiveMinutesAgo)
+          noMetricsFirstDetected.set(maticKey, fiveMinutesAgo)
+
+          await monitorSquids()
+          sendMessageCalls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
+        })
+
+        it('should send one slack alert per network', () => {
+          expect(sendMessageCalls).toHaveLength(2)
+        })
+
+        it('should send a "no metrics found" alert for Ethereum', () => {
+          const call = sendMessageCalls.find(c => c[0].text?.includes('No metrics found') && c[0].text?.includes('ETHEREUM'))
+          expect(call).toBeTruthy()
+        })
+
+        it('should send a "no metrics found" alert for Matic', () => {
+          const call = sendMessageCalls.find(c => c[0].text?.includes('No metrics found') && c[0].text?.includes('MATIC'))
+          expect(call).toBeTruthy()
+        })
+
+        it('should include the issue duration in the Ethereum alert', () => {
+          const call = sendMessageCalls.find(c => c[0].text?.includes('No metrics found') && c[0].text?.includes('ETHEREUM'))
+          const hasDuration = call?.[0].blocks?.some(
+            block =>
+              block.type === 'section' &&
+              block.text !== undefined &&
+              block.text.text.includes('Issue duration:') &&
+              block.text.text.includes('minutes')
+          )
+          expect(hasDuration).toBe(true)
+        })
+      })
+
+      describe('and an alert was just sent in the previous tick', () => {
+        beforeEach(async () => {
+          const fiveMinutesAgo = Date.now() - FIVE_MINUTES - 1000
+          noMetricsFirstDetected.set(ethereumKey, fiveMinutesAgo)
+          noMetricsFirstDetected.set(maticKey, fiveMinutesAgo)
+
+          await monitorSquids()
+          ;(slackComponentMock.sendMessage as jest.Mock).mockClear()
+
+          await monitorSquids()
+        })
+
+        it('should not send any additional slack alerts on the second run', () => {
+          // eslint-disable-next-line @typescript-eslint/unbound-method
+          expect(slackComponentMock.sendMessage).not.toHaveBeenCalled()
+        })
+      })
+    })
+
+    describe('when a previously-alerting squid reports metrics again', () => {
+      const serviceName = 'squid-without-metrics'
+      const ethereumKey = `${serviceName}-ETHEREUM-no-metrics`
+      const maticKey = `${serviceName}-MATIC-no-metrics`
+
+      beforeEach(async () => {
+        const recoveredSquid: Squid = {
+          name: 'Squid Without Metrics',
+          service_name: serviceName,
+          schema_name: 'active-schema',
+          project_active_schema: 'active-schema',
+          created_at: undefined,
+          health_status: undefined,
+          service_status: undefined,
+          version: 1,
+          metrics: {
+            [Network.ETHEREUM]: {
+              sqd_processor_sync_eta_seconds: 5,
+              sqd_processor_last_block: 1000,
+              sqd_processor_chain_height: 1005,
+              sqd_processor_mapping_blocks_per_second: 10
+            },
+            [Network.MATIC]: {
+              sqd_processor_sync_eta_seconds: 3,
+              sqd_processor_last_block: 2000,
+              sqd_processor_chain_height: 2002,
+              sqd_processor_mapping_blocks_per_second: 15
+            }
+          }
+        }
+        noMetricsFirstDetected.set(ethereumKey, Date.now())
+        noMetricsFirstDetected.set(maticKey, Date.now())
+        squidsMock.list = jest.fn().mockResolvedValue([recoveredSquid])
+
+        await monitorSquids()
+      })
+
+      it('should clear the throttle state for both networks', () => {
         expect(noMetricsFirstDetected.size).toBe(0)
+      })
 
-        // Verify that recovery was logged
-        expect(loggerMock.info).toHaveBeenCalledWith('Metrics recovered for squid-without-metrics on ETHEREUM. Clearing throttle state.')
-        expect(loggerMock.info).toHaveBeenCalledWith('Metrics recovered for squid-without-metrics on MATIC. Clearing throttle state.')
+      it('should log that metrics recovered for Ethereum', () => {
+        expect(loggerMock.info).toHaveBeenCalledWith(`Metrics recovered for ${serviceName} on ETHEREUM. Clearing throttle state.`)
+      })
+
+      it('should log that metrics recovered for Matic', () => {
+        expect(loggerMock.info).toHaveBeenCalledWith(`Metrics recovered for ${serviceName} on MATIC. Clearing throttle state.`)
       })
     })
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     "skipLibCheck": true,
     "types": ["jest", "node"]
   },
-  "include": ["src", "test", "jest.setup.ts"]
+  "include": ["src", "test", "scripts", "jest.setup.ts"]
 }


### PR DESCRIPTION
> **Base branch:** `chore/dependency-overhaul` (#74). Merge that first — this depends on `@dcl/job-component` and the new `@dcl/pg-component` `withTransaction` landing there.

## Why

Over time the dapps and credits databases accumulate `squid_*` schemas from old deployments that nobody references anymore — every promote leaves a renamed "old" schema behind, and failed or abandoned deployments leave their working schemas in place. There's currently no cleanup path, so the databases grow indefinitely. This PR adds a safe, opt-in background cleanup that drops schemas that are both sufficiently old and provably unreferenced.

## How

### New method: `ISquidComponent.purgeOldSchemas({ olderThanMs, dryRun? })`

Per database (dapps + credits):

1. **Candidates**: `information_schema.schemata` filtered to `squid_%`.
2. **Age**: `MAX(indexers.created_at)` per schema. If there's no row, the schema is not ours — **silently skipped**, never reported, never touched. We only act on what we know we created.
3. **Don't-touch set**:
   - every `public.squids.schema` (the currently promoted schema for each project), and
   - for every ECS service with a running task, the most recent `indexers.schema` for that service (the freshly deployed, not-yet-promoted schema).
4. **Drop**: for each candidate that's old enough and absent from the don't-touch set, inside a single `withTransaction`: `DROP SCHEMA <name> CASCADE` then `DELETE FROM public.indexers WHERE schema = <name>`.

Result shape surfaces deleted schemas + reasons for schemas that were old enough to be candidates but protected: `active` / `running-service` / `invalid-name`.

### Safety rails
- **Name gate**: `^squid_[a-zA-Z0-9_]+$` is checked immediately before every DROP. Anything outside that shape is reported skipped, never executed.
- **ECS abort**: if the lookup of running services fails or returns zero squids, the purge aborts before touching a database. An ECS blip must not be read as "nothing is running".
- **Transaction per schema**: a DROP and its indexers DELETE either both commit or both roll back.
- **Independent DB handling**: a failure processing dapps is logged and credits still runs (and vice versa).
- **Dry-run** flag so operators can preview the decision without executing.

### Why a new `getRunningSquidServiceNames` helper instead of calling `list()`

`list()` already enumerates running squids — but it also describes every task and fetches per-network Prometheus metrics over HTTP. For a daily cleanup that only needs "which services have a running task", that's wasted work and makes the tests combinatorially harder to set up. The new helper does just `ListServices → DescribeServices → ListTasks` and returns the service names.

### Daily job wiring

`src/components.ts` now creates a second job (alongside the squid monitor) with `createJobComponent` on a 24h interval, 5-minute startup delay to avoid racing boot. The job callback reads `SCHEMA_PURGE_MAX_AGE_DAYS`; if unset or ≤0 it logs once and returns — the feature is **opt-in per environment**. No default age is baked in on purpose: operators choose when they're ready.

## Test plan
- [x] 14/14 unit tests pass (4 new cases for purge: empty ECS, ECS error, happy path with mix of active/running/no-history/old-orphan, dry-run).
- [x] Coverage on `src/ports/squids/component.ts` 72% → 81%.
- [ ] Before enabling in prod: run once with `dryRun: true` (can expose via a one-off script or endpoint if useful) and review the list.
- [ ] First prod rollout: set `SCHEMA_PURGE_MAX_AGE_DAYS` to something conservative (e.g. 60–90 days), watch the `schema-purge-job` logger for a week, then tune.