### PR TITLE
feat: add /:id/is-live endpoint to detect promoted squid services

### DIFF
--- a/src/controllers/handlers/squid-handler.ts
+++ b/src/controllers/handlers/squid-handler.ts
@@ -37,6 +37,31 @@ export async function stopSquidHandler(context: Pick<HandlerContextWithPath<'squ
   }
 }
 
+export async function isLiveSquidHandler(
+  context: Pick<HandlerContextWithPath<'squids', '/squids/:id/is-live'>, 'params' | 'components'>
+) {
+  const {
+    components: { squids },
+    params: { id }
+  } = context
+
+  try {
+    const result = await squids.isLive(id)
+    return {
+      status: StatusCode.OK,
+      body: result
+    }
+  } catch (e) {
+    console.error('error: ', e)
+    return {
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        message: isErrorWithMessage(e) ? e.message : 'Could not determine live status'
+      }
+    }
+  }
+}
+
 export async function promoteSquidHandler(context: Pick<HandlerContextWithPath<'squids', '/squids/:id/promote'>, 'params' | 'components'>) {
   const {
     components: { squids },

--- a/src/controllers/handlers/squid-handler.ts
+++ b/src/controllers/handlers/squid-handler.ts
@@ -37,9 +37,7 @@ export async function stopSquidHandler(context: Pick<HandlerContextWithPath<'squ
   }
 }
 
-export async function isLiveSquidHandler(
-  context: Pick<HandlerContextWithPath<'squids', '/squids/:id/is-live'>, 'params' | 'components'>
-) {
+export async function isLiveSquidHandler(context: Pick<HandlerContextWithPath<'squids', '/squids/:id/is-live'>, 'params' | 'components'>) {
   const {
     components: { squids },
     params: { id }

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -1,12 +1,13 @@
 import { Router } from '@dcl/http-server'
 import { GlobalContext } from '../types'
-import { listSquidsHandler, promoteSquidHandler, stopSquidHandler } from './handlers/squid-handler'
+import { isLiveSquidHandler, listSquidsHandler, promoteSquidHandler, stopSquidHandler } from './handlers/squid-handler'
 
 // We return the entire router because it will be easier to test than a whole server
 export async function setupRouter(): Promise<Router<GlobalContext>> {
   const router = new Router<GlobalContext>()
 
   router.get('/list', listSquidsHandler)
+  router.get('/:id/is-live', isLiveSquidHandler)
   router.put('/:id/promote', promoteSquidHandler)
   router.put('/:id/stop', stopSquidHandler)
 

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -11,7 +11,7 @@ import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known
 import { IPgComponent } from '@dcl/pg-component'
 import { Network } from '@dcl/schemas'
 import { getActiveSchemaQuery, getPromoteQuery, getSchemaByServiceNameQuery } from './queries'
-import { ISquidComponent, Squid, SquidMetric } from './types'
+import { ISquidComponent, IsLiveResult, Squid, SquidMetric } from './types'
 import { getMetricValue, getProjectNameFromService, getSquidsNetworksMapping } from './utils'
 
 const AWS_REGION = 'us-east-1'
@@ -237,9 +237,31 @@ export async function createSubsquidComponent({
     }
   }
 
+  /**
+   * Returns whether `serviceName` is currently the LIVE indexer for its project.
+   * "Live" = its most recent indexers row's schema matches the project's promoted
+   * schema in the squids table (the schema the API actually queries).
+   *
+   * Returns { live: false, schema: null, activeSchema: null } if the service has
+   * no indexers row or the project has no entry in the squids table — "not live"
+   * is the safe default.
+   */
+  async function isLive(serviceName: string): Promise<IsLiveResult> {
+    const database = getDatabaseFromServiceName(serviceName)
+    const [schemaRes, activeRes] = await Promise.all([
+      database.query<{ schema: string }>(getSchemaByServiceNameQuery(serviceName)),
+      database.query<{ schema: string }>(getActiveSchemaQuery(serviceName))
+    ])
+    const schema = schemaRes.rows[0]?.schema ?? null
+    const activeSchema = activeRes.rows[0]?.schema ?? null
+    const live = schema !== null && activeSchema !== null && schema === activeSchema
+    return { live, schema, activeSchema }
+  }
+
   return {
     list,
     promote,
-    downgrade
+    downgrade,
+    isLive
   }
 }

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -21,8 +21,15 @@ export type Squid = {
   metrics: Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
 }
 
+export type IsLiveResult = {
+  live: boolean
+  schema: string | null
+  activeSchema: string | null
+}
+
 export type ISquidComponent = {
   list(): Promise<Squid[]>
   downgrade(serviceName: string): Promise<void>
   promote(serviceName: string): Promise<void>
+  isLive(serviceName: string): Promise<IsLiveResult>
 }

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -117,6 +117,96 @@ describe('createSubsquidComponent', () => {
     })
   })
 
+  describe('isLive', () => {
+    it('returns live=true when latest indexer schema matches the project active schema', async () => {
+      ;(dappsDatabaseMock.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] }) // getSchemaByServiceNameQuery
+        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] }) // getActiveSchemaQuery
+
+      const subsquid = await createSubsquidComponent({
+        fetch: fetchMock,
+        dappsDatabase: dappsDatabaseMock,
+        creditsDatabase: creditsDatabaseMock,
+        config: configMock,
+        logs: logsMock
+      })
+
+      const result = await subsquid.isLive('marketplace-squid-server-a')
+
+      expect(result).toEqual({
+        live: true,
+        schema: 'marketplace_squid_20250101',
+        activeSchema: 'marketplace_squid_20250101'
+      })
+    })
+
+    it('returns live=false when schemas differ', async () => {
+      ;(dappsDatabaseMock.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250105' }] })
+        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] })
+
+      const subsquid = await createSubsquidComponent({
+        fetch: fetchMock,
+        dappsDatabase: dappsDatabaseMock,
+        creditsDatabase: creditsDatabaseMock,
+        config: configMock,
+        logs: logsMock
+      })
+
+      const result = await subsquid.isLive('marketplace-squid-server-a')
+
+      expect(result).toEqual({
+        live: false,
+        schema: 'marketplace_squid_20250105',
+        activeSchema: 'marketplace_squid_20250101'
+      })
+    })
+
+    it('returns live=false with null fields when service has no indexer row', async () => {
+      ;(dappsDatabaseMock.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [] }) // no indexer row
+        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] })
+
+      const subsquid = await createSubsquidComponent({
+        fetch: fetchMock,
+        dappsDatabase: dappsDatabaseMock,
+        creditsDatabase: creditsDatabaseMock,
+        config: configMock,
+        logs: logsMock
+      })
+
+      const result = await subsquid.isLive('marketplace-squid-server-a')
+
+      expect(result).toEqual({
+        live: false,
+        schema: null,
+        activeSchema: 'marketplace_squid_20250101'
+      })
+    })
+
+    it('routes to creditsDatabase for credits-squid services', async () => {
+      ;(creditsDatabaseMock.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [{ schema: 'credits_squid_x' }] })
+        .mockResolvedValueOnce({ rows: [{ schema: 'credits_squid_x' }] })
+
+      const subsquid = await createSubsquidComponent({
+        fetch: fetchMock,
+        dappsDatabase: dappsDatabaseMock,
+        creditsDatabase: creditsDatabaseMock,
+        config: configMock,
+        logs: logsMock
+      })
+
+      const result = await subsquid.isLive('credits-squid-server-a')
+
+      expect(result.live).toBe(true)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(creditsDatabaseMock.query).toHaveBeenCalledTimes(2)
+      // eslint-disable-next-line @typescript-eslint/unbound-method
+      expect(dappsDatabaseMock.query).not.toHaveBeenCalled()
+    })
+  })
+
   describe('downgrade', () => {
     beforeEach(() => {
       ;(ecsClientMock.send as jest.Mock).mockResolvedValue({})

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -38,7 +38,8 @@ describe('Squid Monitor', () => {
     squidsMock = {
       list: jest.fn().mockResolvedValue([]),
       downgrade: jest.fn(),
-      promote: jest.fn()
+      promote: jest.fn(),
+      isLive: jest.fn().mockResolvedValue({ live: false, schema: null, activeSchema: null })
     }
 
     // Mock the Slack component


### PR DESCRIPTION
# feat: add `/:id/is-live` endpoint to detect promoted squid services

## Summary

Adds a read-only endpoint that reports whether a given squid service is the **LIVE** indexer for its project — i.e., whether its latest indexed schema is the one currently promoted in the `squids` table (the schema the marketplace API actually queries).

This is the foundation for a deploy guard that prevents accidentally deploying on top of the LIVE indexer (separate PR in `marketplace-squid-core`).

## Why

Today the deploy GitHub Action takes `(env, server a/b, image tag)` and pushes blindly. If the target server happens to be the LIVE one, `indexer.sh` creates a new schema and starts indexing from genesis, while the previously-promoted schema gets frozen in time — the marketplace API gradually serves staler and staler data. Detecting "is this slot LIVE?" before deploying lets us block the dangerous case.

The management server already has the data needed (`indexers.schema` vs `squids.schema`); we just expose it.

## Changes

### `src/ports/squids/types.ts`
- New `IsLiveResult` type: `{ live, schema, activeSchema }`.
- `ISquidComponent.isLive(serviceName)` added to the interface.

### `src/ports/squids/component.ts`
- Implements `isLive` reusing the existing `getSchemaByServiceNameQuery` and `getActiveSchemaQuery`. Routes to `dappsDatabase` or `creditsDatabase` based on service name (same logic as `list`).
- "Live" iff both queries return a schema and they match. Missing/empty rows return `live=false` with the corresponding fields as `null` — safe default for a guard.

### `src/controllers/handlers/squid-handler.ts`
- New `isLiveSquidHandler` following the same pattern as the existing handlers.

### `src/controllers/routes.ts`
- Wires `GET /:id/is-live`. Public (consistent with the rest of the endpoints — gated by VPC/network).

### Tests
- `test/unit/squid-controller.spec.ts`: 4 new unit tests covering live=true, live=false on schema mismatch, missing indexer row, and credits-DB routing.
- `test/unit/squid-monitor.spec.ts`: 1-line update to satisfy the new interface in the existing mock.

## API

```
GET /:serviceName/is-live
```

Response 200:
```json
{
  "live": true,
  "schema": "marketplace_squid_20251101_120000",
  "activeSchema": "marketplace_squid_20251101_120000"
}
```

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 14/14 pass (3 existing + 4 new for `isLive`, plus the rest of the suite)
- [ ] After deploy to dev: `curl https://squid-management-server.decentraland.zone/marketplace-squid-server-a/is-live` returns valid JSON
- [ ] Same against prd

## Rollout

This must be deployed to dev and prd **before** the corresponding `marketplace-squid-core` workflow change is merged — otherwise the new deploy guard hits a 404. Backwards-compatible: no existing endpoints change.

## Follow-ups (not in this PR)

- Mirror the deploy guard to `trades-squid-core` and `credits-squid-core` workflows (the endpoint already routes to the right DB for any service name).
- Separate concern: during `promote()`, also update `indexers.schema` to the canonical post-rename name so post-promote restarts don't point to a stale schema name.
