### PR TITLE
feat: use project and slot for is-live endpoint

### DIFF
--- a/src/controllers/handlers/squid-handler.ts
+++ b/src/controllers/handlers/squid-handler.ts
@@ -37,14 +37,30 @@ export async function stopSquidHandler(context: Pick<HandlerContextWithPath<'squ
   }
 }
 
-export async function isLiveSquidHandler(context: Pick<HandlerContextWithPath<'squids', '/squids/:id/is-live'>, 'params' | 'components'>) {
+// Restricts URL params that are interpolated into a SQL LIKE pattern.
+// Allows lowercase letters, digits and hyphens only (Decentraland project + slot
+// identifiers are e.g. "marketplace", "trades", "credits", "a", "b").
+const SAFE_PARAM_RE = /^[a-z0-9-]+$/
+
+export async function isLiveSquidHandler(
+  context: Pick<HandlerContextWithPath<'squids', '/:project/:slot/is-live'>, 'params' | 'components'>
+) {
   const {
     components: { squids },
-    params: { id }
+    params: { project, slot }
   } = context
 
+  if (!SAFE_PARAM_RE.test(project) || !SAFE_PARAM_RE.test(slot)) {
+    return {
+      status: StatusCode.BAD_REQUEST,
+      body: {
+        message: 'Invalid project or slot. Allowed: lowercase letters, digits, hyphen.'
+      }
+    }
+  }
+
   try {
-    const result = await squids.isLive(id)
+    const result = await squids.isLive(project, slot)
     return {
       status: StatusCode.OK,
       body: result

--- a/src/controllers/routes.ts
+++ b/src/controllers/routes.ts
@@ -7,7 +7,7 @@ export async function setupRouter(): Promise<Router<GlobalContext>> {
   const router = new Router<GlobalContext>()
 
   router.get('/list', listSquidsHandler)
-  router.get('/:id/is-live', isLiveSquidHandler)
+  router.get('/:project/:slot/is-live', isLiveSquidHandler)
   router.put('/:id/promote', promoteSquidHandler)
   router.put('/:id/stop', stopSquidHandler)
 

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -10,7 +10,13 @@ import {
 import { IConfigComponent, IFetchComponent, ILoggerComponent } from '@well-known-components/interfaces'
 import { IPgComponent } from '@dcl/pg-component'
 import { Network } from '@dcl/schemas'
-import { getActiveSchemaQuery, getPromoteQuery, getSchemaByServiceNameQuery } from './queries'
+import {
+  getActiveSchemaByProjectQuery,
+  getActiveSchemaQuery,
+  getLatestSlotServicesQuery,
+  getPromoteQuery,
+  getSchemaByServiceNameQuery
+} from './queries'
 import { ISquidComponent, IsLiveResult, Squid, SquidMetric } from './types'
 import { getMetricValue, getProjectNameFromService, getSquidsNetworksMapping } from './utils'
 
@@ -238,24 +244,34 @@ export async function createSubsquidComponent({
   }
 
   /**
-   * Returns whether `serviceName` is currently the LIVE indexer for its project.
-   * "Live" = its most recent indexers row's schema matches the project's promoted
-   * schema in the squids table (the schema the API actually queries).
+   * Returns whether the given (project, slot) is currently serving as the LIVE
+   * indexer. A slot can have several ECS services running side-by-side during
+   * blue/green transitions (e.g., `marketplace-squid-server-a-blue-92e812a` and
+   * `marketplace-squid-server-a-green-abc1234` may coexist). The slot is LIVE if
+   * any of its services has its latest indexers.schema matching the project's
+   * promoted schema in the squids table.
    *
-   * Returns { live: false, schema: null, activeSchema: null } if the service has
-   * no indexers row or the project has no entry in the squids table — "not live"
-   * is the safe default.
+   * Returns live=false (safe default) if the project has no entry in `squids`
+   * or no service in the slot has an indexers row.
+   *
+   * `project` and `slot` are validated against a safe alphanumeric+hyphen charset
+   * upstream by the handler, since `slot` is interpolated into a LIKE pattern.
    */
-  async function isLive(serviceName: string): Promise<IsLiveResult> {
-    const database = getDatabaseFromServiceName(serviceName)
-    const [schemaRes, activeRes] = await Promise.all([
-      database.query<{ schema: string }>(getSchemaByServiceNameQuery(serviceName)),
-      database.query<{ schema: string }>(getActiveSchemaQuery(serviceName))
+  async function isLive(project: string, slot: string): Promise<IsLiveResult> {
+    const database = project === 'credits' ? creditsDatabase : dappsDatabase
+    const [activeRes, slotRes] = await Promise.all([
+      database.query<{ schema: string }>(getActiveSchemaByProjectQuery(project)),
+      database.query<{ service: string; schema: string }>(getLatestSlotServicesQuery(project, slot))
     ])
-    const schema = schemaRes.rows[0]?.schema ?? null
     const activeSchema = activeRes.rows[0]?.schema ?? null
-    const live = schema !== null && activeSchema !== null && schema === activeSchema
-    return { live, schema, activeSchema }
+    const services = slotRes.rows
+    const liveService = activeSchema ? (services.find(s => s.schema === activeSchema)?.service ?? null) : null
+    return {
+      live: liveService !== null,
+      activeSchema,
+      liveService,
+      services
+    }
   }
 
   return {

--- a/src/ports/squids/queries.ts
+++ b/src/ports/squids/queries.ts
@@ -113,3 +113,33 @@ export const getActiveSchemaQuery = (serviceName: string): SQLStatement => {
       WHERE name = ${projectName};
   `
 }
+
+/**
+ * For a given project, returns the canonical promoted schema (squids.schema).
+ * Same as getActiveSchemaQuery but parameterized by project name directly.
+ */
+export const getActiveSchemaByProjectQuery = (project: string): SQLStatement => {
+  return SQL`
+      SELECT schema
+      FROM public.squids
+      WHERE name = ${project};
+  `
+}
+
+/**
+ * For a given project + slot (a/b), returns the latest indexers row per service
+ * matching the prefix `<project>-squid-server-<slot>-`. Each row is one ECS service
+ * currently associated with that slot (blue/green can have multiple side-by-side).
+ *
+ * The slot is interpolated into a LIKE pattern, so we restrict it to a safe charset
+ * upstream in the component.
+ */
+export const getLatestSlotServicesQuery = (project: string, slot: string): SQLStatement => {
+  const prefix = `${project}-squid-server-${slot}-`
+  return SQL`
+      SELECT DISTINCT ON (service) service, schema
+      FROM public.indexers
+      WHERE service LIKE ${prefix + '%'}
+      ORDER BY service, created_at DESC;
+  `
+}

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -21,15 +21,21 @@ export type Squid = {
   metrics: Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
 }
 
+export type SlotService = {
+  service: string
+  schema: string
+}
+
 export type IsLiveResult = {
   live: boolean
-  schema: string | null
   activeSchema: string | null
+  liveService: string | null
+  services: SlotService[]
 }
 
 export type ISquidComponent = {
   list(): Promise<Squid[]>
   downgrade(serviceName: string): Promise<void>
   promote(serviceName: string): Promise<void>
-  isLive(serviceName: string): Promise<IsLiveResult>
+  isLive(project: string, slot: string): Promise<IsLiveResult>
 }

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -118,10 +118,15 @@ describe('createSubsquidComponent', () => {
   })
 
   describe('isLive', () => {
-    it('returns live=true when latest indexer schema matches the project active schema', async () => {
+    it('returns live=true when one of the slot services has its latest schema matching the active schema', async () => {
       ;(dappsDatabaseMock.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] }) // getSchemaByServiceNameQuery
-        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] }) // getActiveSchemaQuery
+        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] }) // getActiveSchemaByProjectQuery
+        .mockResolvedValueOnce({
+          rows: [
+            { service: 'marketplace-squid-server-a-blue-92e812a', schema: 'marketplace_squid_20250101' },
+            { service: 'marketplace-squid-server-a-green-abc1234', schema: 'marketplace_squid_20250105' }
+          ]
+        }) // getLatestSlotServicesQuery
 
       const subsquid = await createSubsquidComponent({
         fetch: fetchMock,
@@ -131,19 +136,25 @@ describe('createSubsquidComponent', () => {
         logs: logsMock
       })
 
-      const result = await subsquid.isLive('marketplace-squid-server-a')
+      const result = await subsquid.isLive('marketplace', 'a')
 
       expect(result).toEqual({
         live: true,
-        schema: 'marketplace_squid_20250101',
-        activeSchema: 'marketplace_squid_20250101'
+        activeSchema: 'marketplace_squid_20250101',
+        liveService: 'marketplace-squid-server-a-blue-92e812a',
+        services: [
+          { service: 'marketplace-squid-server-a-blue-92e812a', schema: 'marketplace_squid_20250101' },
+          { service: 'marketplace-squid-server-a-green-abc1234', schema: 'marketplace_squid_20250105' }
+        ]
       })
     })
 
-    it('returns live=false when schemas differ', async () => {
+    it('returns live=false when no slot service matches the active schema', async () => {
       ;(dappsDatabaseMock.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250105' }] })
         .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] })
+        .mockResolvedValueOnce({
+          rows: [{ service: 'marketplace-squid-server-b-blue-1', schema: 'marketplace_squid_20250105' }]
+        })
 
       const subsquid = await createSubsquidComponent({
         fetch: fetchMock,
@@ -153,19 +164,42 @@ describe('createSubsquidComponent', () => {
         logs: logsMock
       })
 
-      const result = await subsquid.isLive('marketplace-squid-server-a')
+      const result = await subsquid.isLive('marketplace', 'b')
+
+      expect(result.live).toBe(false)
+      expect(result.liveService).toBeNull()
+      expect(result.activeSchema).toBe('marketplace_squid_20250101')
+    })
+
+    it('returns live=false when project has no entry in squids table', async () => {
+      ;(dappsDatabaseMock.query as jest.Mock)
+        .mockResolvedValueOnce({ rows: [] }) // no active schema
+        .mockResolvedValueOnce({
+          rows: [{ service: 'marketplace-squid-server-a-blue-1', schema: 'marketplace_squid_20250101' }]
+        })
+
+      const subsquid = await createSubsquidComponent({
+        fetch: fetchMock,
+        dappsDatabase: dappsDatabaseMock,
+        creditsDatabase: creditsDatabaseMock,
+        config: configMock,
+        logs: logsMock
+      })
+
+      const result = await subsquid.isLive('marketplace', 'a')
 
       expect(result).toEqual({
         live: false,
-        schema: 'marketplace_squid_20250105',
-        activeSchema: 'marketplace_squid_20250101'
+        activeSchema: null,
+        liveService: null,
+        services: [{ service: 'marketplace-squid-server-a-blue-1', schema: 'marketplace_squid_20250101' }]
       })
     })
 
-    it('returns live=false with null fields when service has no indexer row', async () => {
+    it('returns live=false with empty services when slot has no indexer rows', async () => {
       ;(dappsDatabaseMock.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [] }) // no indexer row
         .mockResolvedValueOnce({ rows: [{ schema: 'marketplace_squid_20250101' }] })
+        .mockResolvedValueOnce({ rows: [] })
 
       const subsquid = await createSubsquidComponent({
         fetch: fetchMock,
@@ -175,19 +209,20 @@ describe('createSubsquidComponent', () => {
         logs: logsMock
       })
 
-      const result = await subsquid.isLive('marketplace-squid-server-a')
+      const result = await subsquid.isLive('marketplace', 'a')
 
       expect(result).toEqual({
         live: false,
-        schema: null,
-        activeSchema: 'marketplace_squid_20250101'
+        activeSchema: 'marketplace_squid_20250101',
+        liveService: null,
+        services: []
       })
     })
 
-    it('routes to creditsDatabase for credits-squid services', async () => {
-      ;(creditsDatabaseMock.query as jest.Mock)
-        .mockResolvedValueOnce({ rows: [{ schema: 'credits_squid_x' }] })
-        .mockResolvedValueOnce({ rows: [{ schema: 'credits_squid_x' }] })
+    it('routes to creditsDatabase when project is "credits"', async () => {
+      ;(creditsDatabaseMock.query as jest.Mock).mockResolvedValueOnce({ rows: [{ schema: 'squid_credits' }] }).mockResolvedValueOnce({
+        rows: [{ service: 'credits-squid-server-a-blue-1', schema: 'squid_credits' }]
+      })
 
       const subsquid = await createSubsquidComponent({
         fetch: fetchMock,
@@ -197,7 +232,7 @@ describe('createSubsquidComponent', () => {
         logs: logsMock
       })
 
-      const result = await subsquid.isLive('credits-squid-server-a')
+      const result = await subsquid.isLive('credits', 'a')
 
       expect(result.live).toBe(true)
       // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -39,7 +39,7 @@ describe('Squid Monitor', () => {
       list: jest.fn().mockResolvedValue([]),
       downgrade: jest.fn(),
       promote: jest.fn(),
-      isLive: jest.fn().mockResolvedValue({ live: false, schema: null, activeSchema: null })
+      isLive: jest.fn().mockResolvedValue({ live: false, activeSchema: null, liveService: null, services: [] })
     }
 
     // Mock the Slack component


### PR DESCRIPTION
# feat: add `/:project/:slot/is-live` endpoint to detect promoted slot

## Summary

Adds a read-only endpoint that reports whether a given **slot** (e.g., `marketplace/a`) is currently the LIVE indexer for its project — i.e., whether any of the ECS services currently running in that slot has its latest indexed schema matching the schema promoted in the `squids` table (the schema the marketplace API actually queries).

This is the foundation for a deploy guard that prevents accidentally deploying on top of the LIVE indexer (separate PR in `marketplace-squid-core`).

## Why a slot-level endpoint, not a service-level one

Decentraland squid services follow a blue/green ECS deploy pattern: at any time the slot `a` may have services like `marketplace-squid-server-a-blue-92e812a` and `marketplace-squid-server-a-green-abc1234` running side-by-side during a deploy transition. The deploy GitHub Action only knows the slot (`a` or `b`), not which color/commit-hash service is currently active. So the natural granularity for "is this thing LIVE?" is the slot, and the endpoint must aggregate over all ECS services matching the slot prefix.

## Why now

Today the deploy GitHub Action takes `(env, server a/b, image tag)` and pushes blindly. If the target slot is the LIVE one, `indexer.sh` creates a new schema and starts indexing from genesis, while the previously-promoted schema gets frozen — the marketplace API gradually serves staler and staler data. Detecting "is this slot LIVE?" before deploying lets us block the dangerous case.

## Changes

### `src/ports/squids/queries.ts`
- New `getActiveSchemaByProjectQuery(project)` — same as `getActiveSchemaQuery` but parameterized by project name directly (the existing one derives project from a service name).
- New `getLatestSlotServicesQuery(project, slot)` — returns the latest indexers row per service whose name matches the prefix `<project>-squid-server-<slot>-`. Uses `DISTINCT ON (service)` + `ORDER BY service, created_at DESC` so we only keep the most recent row per service.

### `src/ports/squids/types.ts`
- `IsLiveResult` shape: `{ live, activeSchema, liveService, services }`.
- `ISquidComponent.isLive(project, slot)` added to the interface.

### `src/ports/squids/component.ts`
- Implements `isLive(project, slot)`:
  - DB routing: `creditsDatabase` if project is `credits`, otherwise `dappsDatabase`.
  - Runs both queries in parallel.
  - `live = true` iff some service in the slot has its latest schema matching the project's promoted schema.
  - Returns the matched service in `liveService` for richer error messaging from the consumer.

### `src/controllers/handlers/squid-handler.ts`
- New `isLiveSquidHandler` follows the same pattern as the existing handlers.
- Validates `project` and `slot` URL params against `^[a-z0-9-]+$` before doing anything — `slot` is interpolated into a SQL LIKE pattern, so we want to reject anything outside a safe charset.

### `src/controllers/routes.ts`
- Wires `GET /:project/:slot/is-live`. Public at the application layer (consistent with the rest of the endpoints — gated by Cloudflare Access at the infra layer).

### Tests
- `test/unit/squid-controller.spec.ts`: 5 unit tests covering live=true with multiple services in the slot, live=false on schema mismatch, no project entry, no slot rows, and credits-DB routing.
- `test/unit/squid-monitor.spec.ts`: 1-line update to the existing mock to satisfy the new interface.

## API

```
GET /:project/:slot/is-live
```

Response 200:
```json
{
  "live": true,
  "activeSchema": "marketplace_squid_20251101_120000",
  "liveService": "marketplace-squid-server-a-blue-92e812a",
  "services": [
    { "service": "marketplace-squid-server-a-blue-92e812a", "schema": "marketplace_squid_20251101_120000" },
    { "service": "marketplace-squid-server-a-green-abc1234", "schema": "marketplace_squid_20251105_090000" }
  ]
}
```

Response 400 if project/slot don't match `^[a-z0-9-]+$`.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` — 15/15 pass (3 existing list/promote/downgrade + 5 new for `isLive` + the rest of squid-monitor)
- [ ] After deploy to dev, with a Cloudflare Access service token: `curl -H "CF-Access-Client-Id: …" -H "CF-Access-Client-Secret: …" https://squid-management-server.decentraland.zone/marketplace/a/is-live` returns valid JSON
- [ ] Same against prd

## Rollout

This must be deployed to dev and prd **before** the corresponding `marketplace-squid-core` workflow change is merged — otherwise the new deploy guard hits a 404. Backwards-compatible: no existing endpoints change.

## Follow-ups (not in this PR)

- Mirror the deploy guard to `trades-squid-core` and `credits-squid-core` workflows (the endpoint already routes to the right DB based on project name).
- Separate concern: during `promote()`, also update `indexers.schema` to the canonical post-rename name so post-promote restarts don't point to a stale schema name.
