### PR TITLE
feat: add sync progress and cache topology for frequent polling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,8 @@ SLACK_CHANNEL=alerts
 ENV=dev
 USE_MOCK_SQUIDS=true
 FORCE_ETA_UNAVAILABLE=false
+
+# How long (ms) the squid topology (ECS + schema info) is cached before re-discovering.
+# The live processor metrics are always scraped fresh, so this only throttles ECS API calls.
+# Lower it to react faster to deploys; raise it to reduce ECS load under frequent polling.
+SQUID_TOPOLOGY_CACHE_TTL_MS=30000

--- a/README.md
+++ b/README.md
@@ -13,6 +13,34 @@ The server includes a daemon that monitors active squids every minute. This daem
 
 In either case, the daemon sends an alert through Slack with detailed information about the affected squid.
 
+### Sync progress
+
+The `GET /list` endpoint returns, for every squid and network, a `metrics` object with the live
+processor values scraped from each indexer. On top of the raw values it now includes a derived
+`progress` field: the percentage of the chain that has been indexed, computed as
+`sqd_processor_last_block / sqd_processor_chain_height` and clamped to the `[0, 100]` range. It is
+`0` when the chain height is unknown. This lets clients render an indexing progress bar without
+re-deriving the value.
+
+### Topology caching (frequent polling)
+
+The expensive part of `GET /list` is discovering the squid topology from ECS (listing/describing
+services and tasks) and resolving each schema from the database. That topology changes rarely, so it
+is cached in memory while the live processor metrics are always scraped fresh on every request. This
+makes the endpoint cheap to poll every few seconds (e.g. to drive a live UI) without hammering the
+ECS API. The cache is invalidated automatically after a `promote` or `stop`, so those changes are
+reflected immediately.
+
+The cache TTL is configurable:
+
+```
+SQUID_TOPOLOGY_CACHE_TTL_MS=30000
+```
+
+- `SQUID_TOPOLOGY_CACHE_TTL_MS`: how long (in milliseconds) the topology is cached before being
+  re-discovered. Defaults to `30000`. Lower it to react faster to deploys; raise it to further
+  reduce ECS load under frequent polling.
+
 ## Configuration
 
 To enable Slack alerts, you need to configure the following environment variables:

--- a/src/ports/job/mocks.ts
+++ b/src/ports/job/mocks.ts
@@ -16,16 +16,18 @@ export const MOCK_SQUIDS: Squid[] = [
       [Network.ETHEREUM]: {
         sqd_processor_sync_eta_seconds: 30, // Intentionally out of sync for testing
         sqd_processor_mapping_blocks_per_second: 5.2,
-        sqd_processor_last_block: 18500000,
-        sqd_processor_chain_height: 18500100
+        sqd_processor_last_block: 18400000,
+        sqd_processor_chain_height: 18500100,
+        progress: 99.46
       },
       [Network.MATIC]: {
         // Note: In real data, this value might be null or undefined even though
         // the type definition doesn't allow it. Our code handles this case.
         sqd_processor_sync_eta_seconds: 0, // We'll use 0 for the mock but the code will still check for null
         sqd_processor_mapping_blocks_per_second: 10.5,
-        sqd_processor_last_block: 45600000,
-        sqd_processor_chain_height: 45600200
+        sqd_processor_last_block: 45600200,
+        sqd_processor_chain_height: 45600200,
+        progress: 100
       }
     }
   }

--- a/src/ports/squids/component.ts
+++ b/src/ports/squids/component.ts
@@ -17,10 +17,11 @@ import {
   getPromoteQuery,
   getSchemaByServiceNameQuery
 } from './queries'
-import { ISquidComponent, IsLiveResult, Squid, SquidMetric } from './types'
-import { getMetricValue, getProjectNameFromService, getSquidsNetworksMapping } from './utils'
+import { ISquidComponent, IsLiveResult, Squid, SquidMetric, SquidServiceTopology } from './types'
+import { computeSyncProgress, getMetricValue, getProjectNameFromService, getSquidsNetworksMapping } from './utils'
 
 const AWS_REGION = 'us-east-1'
+const DEFAULT_TOPOLOGY_CACHE_TTL_MS = 30 * 1000
 
 export async function createSubsquidComponent({
   fetch,
@@ -39,6 +40,16 @@ export async function createSubsquidComponent({
   const cluster = await config.requireString('AWS_CLUSTER_NAME')
   const client = new ECSClient({ region: AWS_REGION })
 
+  // Topology (ECS + schema info) changes rarely, so it is cached to keep frequent
+  // polling cheap. The live processor metrics are always scraped fresh on top of it.
+  const topologyCacheTtl = (await config.getNumber('SQUID_TOPOLOGY_CACHE_TTL_MS')) ?? DEFAULT_TOPOLOGY_CACHE_TTL_MS
+  let cachedTopology: SquidServiceTopology[] | null = null
+  let topologyExpiresAt = 0
+  let inFlightTopology: Promise<SquidServiceTopology[]> | null = null
+  // Bumped on every invalidation so an in-flight discovery started before the
+  // invalidation cannot write its (now stale) result back into the cache.
+  let topologyGeneration = 0
+
   function getDatabaseFromServiceName(serviceName: string): IPgComponent {
     if (serviceName.includes('credits-squid-server')) {
       return creditsDatabase
@@ -46,129 +57,221 @@ export async function createSubsquidComponent({
     return dappsDatabase
   }
 
+  /**
+   * Discovers the squid topology from ECS and the indexers/squids tables. This is
+   * the expensive part (several ECS API calls per service) and excludes the live
+   * processor metrics, which are scraped separately.
+   *
+   * Flow:
+   * 1. List all services in the cluster and keep the squid ones.
+   * 2. Describe those services to get their tasks.
+   * 3. For each service, resolve its writing schema and the project's active schema,
+   *    and read task details (version, status, image, private IP).
+   */
+  async function discoverTopology(): Promise<SquidServiceTopology[]> {
+    // Step 1: List all services
+    const input: ListServicesRequest = {
+      cluster,
+      maxResults: 100
+    }
+    const listServicesCommand = new ListServicesCommand(input)
+    const servicesResponse = await client.send(listServicesCommand)
+
+    const serviceArns = servicesResponse.serviceArns || []
+    const squidServices = serviceArns.filter(arn => arn.includes('-squid-server'))
+
+    // Step 2: Describe services in parallel
+    const describeServicesCommand = new DescribeServicesCommand({
+      cluster,
+      services: squidServices
+    })
+
+    const describeServicesResponse = await client.send(describeServicesCommand)
+    const services = describeServicesResponse.services || []
+
+    // Process all services in parallel
+    return Promise.all(
+      services.map(async squidService => {
+        const serviceName = squidService.serviceName || ''
+        const listTasksCommand = new ListTasksCommand({
+          cluster,
+          serviceName
+        })
+        const taskResponse = await client.send(listTasksCommand)
+        const taskArns = taskResponse.taskArns || []
+
+        const database = getDatabaseFromServiceName(serviceName)
+        const schemaName = (await database.query(getSchemaByServiceNameQuery(serviceName))).rows[0]?.schema
+        const projectActiveSchema = (await database.query(getActiveSchemaQuery(serviceName))).rows[0]?.schema
+
+        const topology: SquidServiceTopology = {
+          service_name: serviceName,
+          schema_name: schemaName,
+          project_active_schema: projectActiveSchema,
+          version: 0,
+          networks: getSquidsNetworksMapping(serviceName)
+        }
+
+        if (taskArns.length === 0) {
+          return topology
+        }
+
+        // Step 3: Describe tasks to get container information
+        const describeTasksCommand = new DescribeTasksCommand({
+          cluster,
+          tasks: taskArns
+        })
+        const describeResponse = await client.send(describeTasksCommand)
+        const tasks = describeResponse.tasks || []
+
+        // there should be just one task per service
+        for (const task of tasks) {
+          topology.version = task.version || 0
+          topology.created_at = task.createdAt
+          topology.health_status = task.healthStatus
+          topology.service_status = task.lastStatus
+
+          // Extract image URI from the task definition containers
+          // Look for the main container (usually the first one or the one with squid in the name)
+          const mainContainer = task.containers?.find(container => container.name?.includes('squid')) || task.containers?.[0]
+
+          if (mainContainer?.image) {
+            topology.image_uri = mainContainer.image
+          }
+
+          const ElasticNetworkInterface = 'ElasticNetworkInterface'
+          const privateIPv4Address = 'privateIPv4Address'
+
+          const ip = task.attachments
+            ?.find(att => att.type === ElasticNetworkInterface)
+            ?.details?.find(detail => detail.name === privateIPv4Address)?.value
+
+          if (ip) {
+            topology.ip = ip
+          }
+        }
+
+        return topology
+      })
+    )
+  }
+
+  /**
+   * Returns the squid topology, served from an in-memory cache with a TTL so that
+   * frequent polling does not hammer the ECS API. Concurrent calls during a cache
+   * miss share a single discovery (single-flight). On a discovery error the stale
+   * cache is served when available and the expiry is not extended, so the next call
+   * retries.
+   */
+  async function getTopology(): Promise<SquidServiceTopology[]> {
+    const now = Date.now()
+    if (cachedTopology && now < topologyExpiresAt) {
+      return cachedTopology
+    }
+
+    if (!inFlightTopology) {
+      const generation = topologyGeneration
+      inFlightTopology = discoverTopology()
+        .then(topology => {
+          // Only write back if no invalidation happened while we were discovering,
+          // otherwise we would resurrect a stale topology with a fresh TTL.
+          if (generation === topologyGeneration) {
+            cachedTopology = topology
+            topologyExpiresAt = Date.now() + topologyCacheTtl
+          }
+          return topology
+        })
+        .catch(error => {
+          logger.error('Error discovering squid topology:', { error: String(error) })
+          return cachedTopology ?? []
+        })
+        .finally(() => {
+          if (generation === topologyGeneration) {
+            inFlightTopology = null
+          }
+        })
+    }
+
+    return inFlightTopology
+  }
+
+  // Forces the next list() to re-discover the topology. Called after operations
+  // that change it (promote/downgrade) so the UI reflects them immediately. Bumping
+  // the generation also discards any discovery currently in flight.
+  function invalidateTopologyCache(): void {
+    cachedTopology = null
+    topologyExpiresAt = 0
+    topologyGeneration++
+    inFlightTopology = null
+  }
+
+  /**
+   * Scrapes the live processor metrics for every network of a squid service and
+   * enriches each one with the derived sync progress. Returns an empty record when
+   * the service has no known IP (e.g. it is stopped).
+   */
+  async function scrapeMetrics(topology: SquidServiceTopology): Promise<Record<Network.ETHEREUM | Network.MATIC, SquidMetric>> {
+    const metrics = {} as Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
+    if (!topology.ip) {
+      return metrics
+    }
+
+    const metricsResults = await Promise.allSettled(
+      topology.networks.map(async network => {
+        const response = await fetch.fetch(`http://${topology.ip}:${network.port}/metrics`)
+        const text = await response.text()
+        const lastBlock = getMetricValue(text, 'sqd_processor_last_block')
+        const chainHeight = getMetricValue(text, 'sqd_processor_chain_height')
+
+        return {
+          networkName: network.name,
+          metrics: {
+            sqd_processor_sync_eta_seconds: getMetricValue(text, 'sqd_processor_sync_eta_seconds'),
+            sqd_processor_mapping_blocks_per_second: getMetricValue(text, 'sqd_processor_mapping_blocks_per_second'),
+            sqd_processor_last_block: lastBlock,
+            sqd_processor_chain_height: chainHeight,
+            progress: computeSyncProgress(lastBlock, chainHeight)
+          }
+        }
+      })
+    )
+
+    metricsResults.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        metrics[result.value.networkName] = result.value.metrics
+      } else {
+        logger.error(`Failed to fetch metrics for network ${topology.networks[index].name}:`, result.reason)
+      }
+    })
+
+    return metrics
+  }
+
   async function list(): Promise<Squid[]> {
     try {
-      // Step 1: List all services
-      const input: ListServicesRequest = {
-        cluster,
-        maxResults: 100
-      }
-      const listServicesCommand = new ListServicesCommand(input)
-      const servicesResponse = await client.send(listServicesCommand)
+      const topology = await getTopology()
 
-      const serviceArns = servicesResponse.serviceArns || []
-      const squidServices = serviceArns.filter(arn => arn.includes('-squid-server'))
-
-      // Step 2: Describe services in parallel
-      const describeServicesCommand = new DescribeServicesCommand({
-        cluster,
-        services: squidServices
-      })
-
-      const describeServicesResponse = await client.send(describeServicesCommand)
-      const services = describeServicesResponse.services || []
-
-      // Process all services in parallel
+      // Scrape the live metrics for every service on top of the cached topology.
       const results = await Promise.all(
-        services.map(async squidService => {
-          const serviceName = squidService.serviceName || ''
-          const listTasksCommand = new ListTasksCommand({
-            cluster,
-            serviceName
-          })
-          const taskResponse = await client.send(listTasksCommand)
-          const taskArns = taskResponse.taskArns || []
-
-          const database = getDatabaseFromServiceName(serviceName)
-          const schemaName = (await database.query(getSchemaByServiceNameQuery(serviceName))).rows[0]?.schema
-          const projectActiveSchema = (await database.query(getActiveSchemaQuery(serviceName))).rows[0]?.schema
+        topology.map(async service => {
+          const metrics = await scrapeMetrics(service)
 
           const squid: Partial<Squid> = {
-            name: serviceName,
-            service_name: serviceName,
-            schema_name: schemaName,
-            project_active_schema: projectActiveSchema,
-            metrics: {} as Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
-          }
-
-          if (taskArns.length === 0) {
-            return squid
-          }
-
-          // Step 3: Describe tasks to get container information
-          const describeTasksCommand = new DescribeTasksCommand({
-            cluster,
-            tasks: taskArns
-          })
-          const describeResponse = await client.send(describeTasksCommand)
-          const tasks = describeResponse.tasks || []
-
-          // there should be just one task per service
-          for (const task of tasks) {
-            squid.version = task.version || 0
-            squid.created_at = task.createdAt
-            squid.health_status = task.healthStatus
-            squid.service_status = task.lastStatus
-
-            // Extract image URI from the task definition containers
-            // Look for the main container (usually the first one or the one with squid in the name)
-            const mainContainer = task.containers?.find(container => container.name?.includes('squid')) || task.containers?.[0]
-
-            if (mainContainer?.image) {
-              squid.image_uri = mainContainer.image
-            }
-
-            const ElasticNetworkInterface = 'ElasticNetworkInterface'
-            const privateIPv4Address = 'privateIPv4Address'
-
-            const ip = task.attachments
-              ?.find(att => att.type === ElasticNetworkInterface)
-              ?.details?.find(detail => detail.name === privateIPv4Address)?.value
-
-            if (!ip) continue
-
-            // Fetch metrics for each network in parallel
-            try {
-              const metricsResults = await Promise.allSettled(
-                getSquidsNetworksMapping(serviceName).map(async network => {
-                  const response = await fetch.fetch(`http://${ip}:${network.port}/metrics`)
-                  const text = await response.text()
-
-                  return {
-                    networkName: network.name,
-                    metrics: {
-                      sqd_processor_sync_eta_seconds: getMetricValue(text, 'sqd_processor_sync_eta_seconds'),
-                      sqd_processor_mapping_blocks_per_second: getMetricValue(text, 'sqd_processor_mapping_blocks_per_second'),
-                      sqd_processor_last_block: getMetricValue(text, 'sqd_processor_last_block'),
-                      sqd_processor_chain_height: getMetricValue(text, 'sqd_processor_chain_height')
-                    }
-                  }
-                })
-              )
-
-              // Process successful metric fetches
-              metricsResults.forEach((result, index) => {
-                if (result.status === 'fulfilled') {
-                  const { networkName, metrics } = result.value
-                  if (!squid.metrics) {
-                    squid.metrics = {
-                      [Network.ETHEREUM]: {} as SquidMetric,
-                      [Network.MATIC]: {} as SquidMetric
-                    }
-                  }
-                  squid.metrics[networkName] = metrics
-                } else {
-                  logger.error(`Failed to fetch metrics for network ${getSquidsNetworksMapping(serviceName)[index].name}:`, result.reason)
-                }
-              })
-            } catch (error) {
-              logger.error(`Failed to fetch metrics for ${ip}:`, { error: String(error) })
-            }
+            name: service.service_name,
+            service_name: service.service_name,
+            schema_name: service.schema_name,
+            project_active_schema: service.project_active_schema,
+            version: service.version,
+            created_at: service.created_at,
+            health_status: service.health_status,
+            service_status: service.service_status,
+            image_uri: service.image_uri,
+            metrics
           }
 
           // Only include complete squid objects
           if (squid.created_at && squid.health_status && squid.service_status) {
-            return squid
+            return squid as Squid
           } else {
             logger.warn(`Skipping incomplete squid: ${squid.service_name}`)
             return null
@@ -192,6 +295,7 @@ export async function createSubsquidComponent({
         desiredCount: 0
       })
       await client.send(updateServiceCommand)
+      invalidateTopologyCache()
       logger.info(`Service ${serviceName} stopped!`)
     } catch (error) {
       logger.error('Error stopping service:', { error: String(error), service: serviceName })
@@ -205,6 +309,9 @@ export async function createSubsquidComponent({
 
     const database = getDatabaseFromServiceName(serviceName)
     await database.query(promoteQuery)
+
+    // The promotion changes the active schema, so drop the cached topology to surface it immediately.
+    invalidateTopologyCache()
 
     logger.info(`The ${serviceName} was promoted and the active schema is ${schemaName}`)
 

--- a/src/ports/squids/types.ts
+++ b/src/ports/squids/types.ts
@@ -6,6 +6,8 @@ export type SquidMetric = {
   sqd_processor_chain_height: number
   sqd_processor_last_block: number
   sqd_processor_mapping_blocks_per_second: number
+  // Derived field (not scraped): percentage of the chain indexed, in the [0, 100] range.
+  progress: number
 }
 
 export type Squid = {
@@ -19,6 +21,25 @@ export type Squid = {
   version: number
   image_uri?: string
   metrics: Record<Network.ETHEREUM | Network.MATIC, SquidMetric>
+}
+
+/**
+ * The "slow-moving" description of a squid service: everything that comes from ECS
+ * and the indexers/squids tables. It deliberately excludes the live processor
+ * metrics, which are scraped fresh on every request. This is what the component
+ * caches so that frequent polling does not hammer the ECS API.
+ */
+export type SquidServiceTopology = {
+  service_name: string
+  schema_name?: string
+  project_active_schema?: string
+  version: number
+  created_at?: Date
+  health_status?: HealthStatus
+  service_status?: string
+  image_uri?: string
+  ip?: string
+  networks: { name: Network.ETHEREUM | Network.MATIC; port: number }[]
 }
 
 export type SlotService = {

--- a/src/ports/squids/utils.ts
+++ b/src/ports/squids/utils.ts
@@ -6,6 +6,23 @@ export const getMetricValue = (metrics: string, metricName: string) => {
   return match ? parseFloat(match[1]) : 0
 }
 
+/**
+ * Computes the indexing progress as the percentage of the chain height that has
+ * already been processed by the squid (last processed block / chain height).
+ *
+ * @param lastBlock - The last block processed by the indexer (sqd_processor_last_block).
+ * @param chainHeight - The current chain tip the indexer is syncing towards (sqd_processor_chain_height).
+ * @returns A value in the [0, 100] range rounded to 2 decimals. Returns 0 when the
+ *          chain height is unknown (0) to avoid a division by zero.
+ */
+export const computeSyncProgress = (lastBlock: number, chainHeight: number): number => {
+  if (!chainHeight || chainHeight <= 0) {
+    return 0
+  }
+  const percentage = (lastBlock / chainHeight) * 100
+  return Math.min(100, Math.max(0, Math.round(percentage * 100) / 100))
+}
+
 export const getProjectNameFromService = (serviceName: string): string => serviceName.split('-squid-server-')[0]
 
 export function getSquidsNetworksMapping(serviceName: string): {

--- a/test/unit/squid-controller.spec.ts
+++ b/test/unit/squid-controller.spec.ts
@@ -20,7 +20,10 @@ describe('createSubsquidComponent', () => {
     fetchMock = { fetch: jest.fn() }
     dappsDatabaseMock = { query: jest.fn() } as unknown as IPgComponent
     creditsDatabaseMock = { query: jest.fn() } as unknown as IPgComponent
-    configMock = { requireString: jest.fn().mockResolvedValue('test-cluster') } as unknown as IConfigComponent
+    configMock = {
+      requireString: jest.fn().mockResolvedValue('test-cluster'),
+      getNumber: jest.fn().mockResolvedValue(undefined)
+    } as unknown as IConfigComponent
     logsMock = {
       getLogger: jest.fn().mockReturnValue({
         info: jest.fn(),
@@ -87,6 +90,51 @@ describe('createSubsquidComponent', () => {
       expect(result[0].project_active_schema).toBe('active-schema')
       expect(result[0].metrics?.ETHEREUM?.sqd_processor_last_block).toBe(1000)
       expect(result[0].metrics?.ETHEREUM?.sqd_processor_sync_eta_seconds).toBe(120)
+    })
+
+    describe('and the metrics expose both the last block and the chain height', () => {
+      beforeEach(() => {
+        ;(fetchMock.fetch as jest.Mock).mockResolvedValue({
+          text: jest.fn().mockResolvedValue(`
+            sqd_processor_last_block 500
+            sqd_processor_chain_height 1000
+            sqd_processor_sync_eta_seconds 120
+          `)
+        })
+      })
+
+      it('should include the derived sync progress in the metrics', async () => {
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+
+        const result = await subsquid.list()
+
+        expect(result[0].metrics?.ETHEREUM?.progress).toBe(50)
+      })
+    })
+
+    describe('and list is called more than once within the cache window', () => {
+      it('should reuse the cached topology and not hit the ECS API again', async () => {
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+
+        await subsquid.list()
+        const ecsCallsAfterFirstList = (ecsClientMock.send as jest.Mock).mock.calls.length
+
+        await subsquid.list()
+
+        expect((ecsClientMock.send as jest.Mock).mock.calls.length).toBe(ecsCallsAfterFirstList)
+      })
     })
   })
 
@@ -266,6 +314,114 @@ describe('createSubsquidComponent', () => {
 
       // eslint-disable-next-line @typescript-eslint/unbound-method
       expect(ecsClientMock.send).toHaveBeenCalledWith(expect.any(UpdateServiceCommand))
+    })
+  })
+
+  describe('topology cache invalidation', () => {
+    let services: { serviceName: string }[]
+    let tasks: unknown[]
+
+    beforeEach(() => {
+      services = [{ serviceName: 'test-squid-service' }]
+      tasks = [
+        {
+          version: 1,
+          createdAt: new Date(),
+          healthStatus: 'HEALTHY',
+          lastStatus: 'RUNNING',
+          attachments: [
+            {
+              type: 'ElasticNetworkInterface',
+              details: [{ name: 'privateIPv4Address', value: '127.0.0.1' }]
+            }
+          ]
+        }
+      ]
+      ;(fetchMock.fetch as jest.Mock).mockResolvedValue({
+        text: jest.fn().mockResolvedValue('sqd_processor_last_block 1000')
+      })
+      ;(dappsDatabaseMock.query as jest.Mock).mockResolvedValue({ rows: [{ schema: 'test-schema' }] })
+    })
+
+    describe('when a squid is downgraded after the topology was cached', () => {
+      beforeEach(() => {
+        ;(ecsClientMock.send as jest.Mock)
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:squid-service'] }) // list #1 - ListServices
+          .mockResolvedValueOnce({ services }) // list #1 - DescribeServices
+          .mockResolvedValueOnce({ taskArns: ['arn:aws:ecs:task/test'] }) // list #1 - ListTasks
+          .mockResolvedValueOnce({ tasks }) // list #1 - DescribeTasks
+          .mockResolvedValueOnce({}) // downgrade - UpdateService
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:squid-service'] }) // list #2 - ListServices
+          .mockResolvedValueOnce({ services }) // list #2 - DescribeServices
+          .mockResolvedValueOnce({ taskArns: ['arn:aws:ecs:task/test'] }) // list #2 - ListTasks
+          .mockResolvedValueOnce({ tasks }) // list #2 - DescribeTasks
+      })
+
+      it('should re-discover the topology on the next list call', async () => {
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+
+        await subsquid.list()
+        await subsquid.downgrade('test-squid-service')
+        await subsquid.list()
+
+        // 4 (first discovery) + 1 (downgrade) + 4 (re-discovery) = 9 ECS calls
+        expect((ecsClientMock.send as jest.Mock).mock.calls.length).toBe(9)
+      })
+    })
+
+    describe('when the cache is invalidated while a discovery is still in flight', () => {
+      let resolveHeldDescribe: (value: unknown) => void
+
+      beforeEach(() => {
+        ;(getPromoteQuery as jest.Mock).mockReturnValue('PROMOTE QUERY')
+        ;(ecsClientMock.send as jest.Mock)
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:squid-service'] }) // list #1 - ListServices
+          .mockImplementationOnce(
+            () =>
+              new Promise(resolve => {
+                resolveHeldDescribe = resolve
+              })
+          ) // list #1 - DescribeServices (held in flight)
+          .mockResolvedValueOnce({ taskArns: ['arn:aws:ecs:task/test'] }) // list #1 - ListTasks
+          .mockResolvedValueOnce({ tasks }) // list #1 - DescribeTasks
+          .mockResolvedValueOnce({ serviceArns: ['arn:aws:squid-service'] }) // list #2 - ListServices
+          .mockResolvedValueOnce({ services }) // list #2 - DescribeServices
+          .mockResolvedValueOnce({ taskArns: ['arn:aws:ecs:task/test'] }) // list #2 - ListTasks
+          .mockResolvedValueOnce({ tasks }) // list #2 - DescribeTasks
+      })
+
+      it('should not resurrect the stale topology and re-discover on the next list', async () => {
+        const subsquid = await createSubsquidComponent({
+          fetch: fetchMock,
+          dappsDatabase: dappsDatabaseMock,
+          creditsDatabase: creditsDatabaseMock,
+          config: configMock,
+          logs: logsMock
+        })
+
+        // Start a discovery that parks on the held DescribeServices call.
+        const firstList = subsquid.list()
+        await new Promise(resolve => setImmediate(resolve))
+
+        // Invalidate the cache (promote performs no ECS calls) while the discovery is in flight.
+        await subsquid.promote('test-squid-service')
+
+        // Let the in-flight discovery finish; its result must NOT be written back to the cache.
+        resolveHeldDescribe({ services })
+        await firstList
+
+        // The next list must re-discover instead of serving the stale in-flight result.
+        await subsquid.list()
+
+        // list #1 (4) + list #2 re-discovery (4) = 8 ECS calls; promote adds none.
+        expect((ecsClientMock.send as jest.Mock).mock.calls.length).toBe(8)
+      })
     })
   })
 })

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -73,13 +73,15 @@ describe('Squid Monitor', () => {
             sqd_processor_sync_eta_seconds: null as unknown as number,
             sqd_processor_last_block: 1000,
             sqd_processor_chain_height: 1010,
-            sqd_processor_mapping_blocks_per_second: 5
+            sqd_processor_mapping_blocks_per_second: 5,
+            progress: 99.01
           },
           [Network.MATIC]: {
             sqd_processor_sync_eta_seconds: undefined as unknown as number,
             sqd_processor_last_block: 2000,
             sqd_processor_chain_height: 2010,
-            sqd_processor_mapping_blocks_per_second: 7
+            sqd_processor_mapping_blocks_per_second: 7,
+            progress: 99.5
           }
         }
       },
@@ -111,13 +113,15 @@ describe('Squid Monitor', () => {
             sqd_processor_sync_eta_seconds: ETA_CONSIDERED_OUT_OF_SYNC + 5,
             sqd_processor_last_block: 1000,
             sqd_processor_chain_height: 1020,
-            sqd_processor_mapping_blocks_per_second: 8
+            sqd_processor_mapping_blocks_per_second: 8,
+            progress: 98.04
           },
           [Network.MATIC]: {
             sqd_processor_sync_eta_seconds: 5,
             sqd_processor_last_block: 2000,
             sqd_processor_chain_height: 2005,
-            sqd_processor_mapping_blocks_per_second: 12
+            sqd_processor_mapping_blocks_per_second: 12,
+            progress: 99.75
           }
         }
       },
@@ -135,13 +139,15 @@ describe('Squid Monitor', () => {
             sqd_processor_sync_eta_seconds: 5,
             sqd_processor_last_block: 1000,
             sqd_processor_chain_height: 1005,
-            sqd_processor_mapping_blocks_per_second: 10
+            sqd_processor_mapping_blocks_per_second: 10,
+            progress: 99.5
           },
           [Network.MATIC]: {
             sqd_processor_sync_eta_seconds: 3,
             sqd_processor_last_block: 2000,
             sqd_processor_chain_height: 2002,
-            sqd_processor_mapping_blocks_per_second: 15
+            sqd_processor_mapping_blocks_per_second: 15,
+            progress: 99.9
           }
         }
       }

--- a/test/unit/squids-utils.spec.ts
+++ b/test/unit/squids-utils.spec.ts
@@ -1,0 +1,39 @@
+import { computeSyncProgress } from '../../src/ports/squids/utils'
+
+describe('computeSyncProgress', () => {
+  describe('when the chain height is zero', () => {
+    it('should return 0 to avoid dividing by zero', () => {
+      expect(computeSyncProgress(1000, 0)).toBe(0)
+    })
+  })
+
+  describe('when the chain height is negative', () => {
+    it('should return 0', () => {
+      expect(computeSyncProgress(1000, -10)).toBe(0)
+    })
+  })
+
+  describe('when the last processed block is behind the chain height', () => {
+    it('should return the percentage rounded to two decimals', () => {
+      expect(computeSyncProgress(500, 1000)).toBe(50)
+    })
+
+    describe('and the division is not exact', () => {
+      it('should round the percentage to two decimals', () => {
+        expect(computeSyncProgress(1000, 1010)).toBe(99.01)
+      })
+    })
+  })
+
+  describe('when the last processed block equals the chain height', () => {
+    it('should return 100', () => {
+      expect(computeSyncProgress(1000, 1000)).toBe(100)
+    })
+  })
+
+  describe('when the last processed block is ahead of the chain height', () => {
+    it('should cap the progress at 100', () => {
+      expect(computeSyncProgress(1100, 1000)).toBe(100)
+    })
+  })
+})


### PR DESCRIPTION
## Context

The UI needs to show live indexing progress (current block per indexer) and refresh every few seconds. Polling `GET /list` that often was unsafe because every call re-discovered the whole squid topology from ECS. This PR makes the endpoint cheap to poll and adds the progress data the UI needs.

## Changes

- **Sync progress %**: every metric returned by `GET /list` now includes a derived `progress` field — the percentage of the chain indexed (`last_block / chain_height`, clamped to `[0, 100]`, `0` when chain height is unknown). Computed server-side in `computeSyncProgress` so it is a single source of truth.
- **Topology caching**: `list()` is split into a cached `getTopology()` (the expensive ECS + schema discovery) and an always-fresh `scrapeMetrics()`. The topology is cached in memory with a configurable TTL (`SQUID_TOPOLOGY_CACHE_TTL_MS`, default `30000`) and discovered via a single-flight promise, so concurrent/rapid polls do not hammer the ECS API while block metrics stay live.
- **Cache invalidation**: the topology cache is invalidated after `promote` and `stop` so those changes surface immediately. A generation counter prevents an in-flight discovery (started before the invalidation) from writing a stale topology back into the cache.
- Docs: documented the new field and config in `README.md` and `.env.example`.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (25 passing, incl. new specs for `computeSyncProgress`, progress in `list`, cache reuse, invalidation on downgrade, and the invalidate-during-in-flight race)