### PR TITLE
fix: throttle out-of-sync alert and add block lag details

### DIFF
--- a/src/ports/job/squid-monitor.ts
+++ b/src/ports/job/squid-monitor.ts
@@ -1,10 +1,12 @@
 import { Network } from '@dcl/schemas'
 import { AppComponents } from '../../types'
 import { Squid } from '../squids/types'
+import { AVERAGE_BLOCK_TIME_SECONDS, formatDuration, getBlocksBehind } from '../squids/utils'
 import { MOCK_SQUIDS } from './mocks'
 
 export const ETA_CONSIDERED_OUT_OF_SYNC = 100
 export const FIVE_MINUTES = 5 * 60 * 1000
+export const TEN_MINUTES = 10 * 60 * 1000
 
 export type SlackMessageBlock = {
   type: 'section' | 'header' | 'divider' | 'context'
@@ -38,9 +40,31 @@ type SquidAlertMessage = {
 // State to track when "no metrics" issues were first detected for throttling alerts
 export const noMetricsFirstDetected = new Map<string, number>()
 
+// State to track when the last "out of sync" alert was sent, to throttle them
+export const desyncAlertLastSent = new Map<string, number>()
+
 // Helper function to clear throttle state (mainly for testing)
 export function clearNoMetricsThrottleState(): void {
   noMetricsFirstDetected.clear()
+}
+
+// Helper function to clear desync throttle state (mainly for testing)
+export function clearDesyncThrottleState(): void {
+  desyncAlertLastSent.clear()
+}
+
+// Removes throttle entries for squids that are no longer active (e.g. after a
+// blue/green deploy changes the service name), so the throttle maps don't grow
+// unbounded over time.
+export function pruneThrottleState(activeServiceNames: string[]): void {
+  const isActive = (key: string): boolean => activeServiceNames.some(service => key.startsWith(`${service}-`))
+  for (const map of [noMetricsFirstDetected, desyncAlertLastSent]) {
+    for (const key of Array.from(map.keys())) {
+      if (!isActive(key)) {
+        map.delete(key)
+      }
+    }
+  }
 }
 
 export async function createSquidMonitor(
@@ -71,6 +95,9 @@ export async function createSquidMonitor(
       for (const squid of activeSquids) {
         await checkSquidSynchronization(squid)
       }
+
+      // Drop throttle state for squids that are no longer active so the maps stay bounded.
+      pruneThrottleState(activeSquids.map(squid => squid.service_name))
     } catch (error) {
       logger.error('❌ Error monitoring squids:', { error: formatError(error) })
 
@@ -285,7 +312,21 @@ export async function createSquidMonitor(
 
       // Check if ETA is greater than 100 seconds
       if (metrics.sqd_processor_sync_eta_seconds > ETA_CONSIDERED_OUT_OF_SYNC) {
+        const desyncKey = `${squid.service_name}-${network}-desync`
+        const now = Date.now()
+        const lastSent = desyncAlertLastSent.get(desyncKey)
+
+        // Throttle: (re)send the out-of-sync alert at most once every 10 minutes.
+        if (lastSent && now - lastSent < TEN_MINUTES) {
+          continue
+        }
+
         const squidDetailsUrl = `${BASE_URL}?squid=${squid.service_name}&network=${network}`
+
+        // How far behind the chain tip the indexer is, in blocks and approximate wall-clock time.
+        const blocksBehind = getBlocksBehind(metrics.sqd_processor_last_block, metrics.sqd_processor_chain_height)
+        const blockTime = AVERAGE_BLOCK_TIME_SECONDS[network as Network.ETHEREUM | Network.MATIC]
+        const behindRealTime = `~${formatDuration(blocksBehind * blockTime)} (≈ ${blockTime}s/block)`
 
         const desyncMessage: SquidAlertMessage = {
           text: `${ENV_PREFIX} ⚠️ ALERT: Squid '${squid.name}' on network ${network} is out of sync`,
@@ -317,15 +358,23 @@ export async function createSquidMonitor(
                 },
                 {
                   type: 'mrkdwn',
-                  text: `*⏱️ Current ETA:* ${metrics.sqd_processor_sync_eta_seconds} seconds`
+                  text: `*⏱️ Sync ETA:* ~${formatDuration(metrics.sqd_processor_sync_eta_seconds)}`
                 },
                 {
                   type: 'mrkdwn',
-                  text: `*📦 Last block:* ${metrics.sqd_processor_last_block}`
+                  text: `*📉 Blocks behind:* ${blocksBehind.toLocaleString('en-US')}`
                 },
                 {
                   type: 'mrkdwn',
-                  text: `*⛓️ Chain height:* ${metrics.sqd_processor_chain_height}`
+                  text: `*🕰️ Behind real-time:* ${behindRealTime}`
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*📦 Last block:* ${metrics.sqd_processor_last_block.toLocaleString('en-US')}`
+                },
+                {
+                  type: 'mrkdwn',
+                  text: `*⛓️ Chain height:* ${metrics.sqd_processor_chain_height.toLocaleString('en-US')}`
                 }
               ]
             },
@@ -349,6 +398,14 @@ export async function createSquidMonitor(
         }
 
         await slack.sendMessage({ channel: slackChannel, ...desyncMessage })
+        desyncAlertLastSent.set(desyncKey, now)
+      } else {
+        // Back in sync: clear any throttle state so a future desync alerts immediately.
+        const desyncKey = `${squid.service_name}-${network}-desync`
+        if (desyncAlertLastSent.has(desyncKey)) {
+          desyncAlertLastSent.delete(desyncKey)
+          logger.info(`Squid ${squid.service_name} on ${network} is back in sync. Clearing desync throttle state.`)
+        }
       }
     }
   }

--- a/src/ports/squids/utils.ts
+++ b/src/ports/squids/utils.ts
@@ -23,6 +23,56 @@ export const computeSyncProgress = (lastBlock: number, chainHeight: number): num
   return Math.min(100, Math.max(0, Math.round(percentage * 100) / 100))
 }
 
+/**
+ * Approximate average block time per network, in seconds. Used to translate a
+ * block lag (chain height - last processed block) into an approximate wall-clock
+ * "behind real-time" figure.
+ *
+ * Sources (June 2026): Ethereum slots are a fixed 12s post-merge; Polygon PoS
+ * reduced its average block time to ~1.75s in May 2026 (down from ~2s). Update
+ * these if the networks change their cadence.
+ */
+export const AVERAGE_BLOCK_TIME_SECONDS: Record<Network.ETHEREUM | Network.MATIC, number> = {
+  [Network.ETHEREUM]: 12,
+  [Network.MATIC]: 1.75
+}
+
+/**
+ * Returns how many blocks the indexer is behind the chain tip, clamped to 0 so a
+ * momentarily stale chain height (last block > chain height) never goes negative.
+ */
+export const getBlocksBehind = (lastBlock: number, chainHeight: number): number => Math.max(0, chainHeight - lastBlock)
+
+/**
+ * Formats a duration in seconds into a short, human-readable string showing the
+ * two most significant units (e.g. "1h 13m", "46m 27s", "45s"). Returns "0s" for
+ * non-positive durations.
+ */
+export const formatDuration = (seconds: number): string => {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return '0s'
+  }
+
+  const total = Math.round(seconds)
+  const units = [
+    { value: Math.floor(total / 86400), label: 'd' },
+    { value: Math.floor((total % 86400) / 3600), label: 'h' },
+    { value: Math.floor((total % 3600) / 60), label: 'm' },
+    { value: total % 60, label: 's' }
+  ]
+
+  const firstIndex = units.findIndex(unit => unit.value > 0)
+  if (firstIndex === -1) {
+    return '0s'
+  }
+
+  return units
+    .slice(firstIndex, firstIndex + 2)
+    .filter(unit => unit.value > 0)
+    .map(unit => `${unit.value}${unit.label}`)
+    .join(' ')
+}
+
 export const getProjectNameFromService = (serviceName: string): string => serviceName.split('-squid-server-')[0]
 
 export function getSquidsNetworksMapping(serviceName: string): {

--- a/test/unit/squid-monitor.spec.ts
+++ b/test/unit/squid-monitor.spec.ts
@@ -5,8 +5,11 @@ import {
   ETA_CONSIDERED_OUT_OF_SYNC,
   FIVE_MINUTES,
   SlackMessageBlock,
+  TEN_MINUTES,
+  clearDesyncThrottleState,
   clearNoMetricsThrottleState,
   createSquidMonitor,
+  desyncAlertLastSent,
   noMetricsFirstDetected
 } from '../../src/ports/job/squid-monitor'
 import { ISquidComponent, Squid, SquidMetric } from '../../src/ports/squids/types'
@@ -23,6 +26,7 @@ describe('Squid Monitor', () => {
   beforeEach(() => {
     // Clear throttle state before each test
     clearNoMetricsThrottleState()
+    clearDesyncThrottleState()
 
     // Mock the logger
     loggerMock = {
@@ -227,16 +231,93 @@ describe('Squid Monitor', () => {
         )
         expect(desyncCall).toBeTruthy()
 
-        // Verify that the message contains the correct information
+        // Verify that the ETA is shown in a human-readable format (105s -> "1m 45s")
         expect(
           desyncCall &&
             desyncCall[0].blocks?.some(
               (block: SlackMessageBlock) =>
                 block.type === 'section' &&
                 block.fields &&
-                block.fields.some(field => field.text.includes('Current ETA') && field.text.includes('5 seconds'))
+                block.fields.some(field => field.text.includes('Sync ETA') && field.text.includes('1m 45s'))
             )
         ).toBeTruthy()
+      })
+
+      it('should include the blocks behind and the approximate time behind real-time', async () => {
+        await monitorSquids()
+
+        const calls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
+        const desyncCall = calls.find(
+          (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
+            call[0].text && call[0].text.includes('out of sync') && call[0].text.includes('ETHEREUM')
+        )
+        const fields: { text: string }[] = (desyncCall?.[0].blocks ?? []).flatMap((block: SlackMessageBlock) => block.fields ?? [])
+
+        // 1020 - 1000 = 20 blocks behind; on Ethereum (12s/block) that is ~240s = "4m"
+        const hasBlocksBehind = fields.some(field => field.text.includes('Blocks behind') && field.text.includes('* 20'))
+        const hasBehindRealTime = fields.some(field => field.text.includes('Behind real-time') && field.text.includes('~4m'))
+
+        expect(hasBlocksBehind && hasBehindRealTime).toBe(true)
+      })
+    })
+
+    describe('when a squid with throttle state is no longer active', () => {
+      beforeEach(() => {
+        desyncAlertLastSent.set('gone-squid-ETHEREUM-desync', Date.now())
+        noMetricsFirstDetected.set('gone-squid-MATIC-no-metrics', Date.now())
+        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[3]]) // only synchronized-squid is active
+      })
+
+      it('should prune the stale throttle entries for the missing squid', async () => {
+        await monitorSquids()
+
+        expect(desyncAlertLastSent.has('gone-squid-ETHEREUM-desync')).toBe(false)
+        expect(noMetricsFirstDetected.has('gone-squid-MATIC-no-metrics')).toBe(false)
+      })
+    })
+
+    describe('when a squid stays out of sync across consecutive runs', () => {
+      beforeEach(() => {
+        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[2]])
+      })
+
+      it('should not resend the out-of-sync alert within 10 minutes', async () => {
+        await monitorSquids()
+        await monitorSquids()
+
+        // eslint-disable-next-line @typescript-eslint/unbound-method
+        expect(slackComponentMock.sendMessage).toHaveBeenCalledTimes(1)
+      })
+
+      describe('and more than 10 minutes have passed since the last alert', () => {
+        beforeEach(() => {
+          desyncAlertLastSent.set('out-of-sync-squid-ETHEREUM-desync', Date.now() - TEN_MINUTES - 1000)
+        })
+
+        it('should resend the out-of-sync alert', async () => {
+          await monitorSquids()
+
+          const calls = (slackComponentMock.sendMessage as jest.Mock).mock.calls
+          const desyncCall = calls.find(
+            (call: [{ text: string; blocks?: SlackMessageBlock[] }]) =>
+              call[0].text && call[0].text.includes('out of sync') && call[0].text.includes('ETHEREUM')
+          )
+          expect(desyncCall).toBeTruthy()
+        })
+      })
+    })
+
+    describe('when a previously out-of-sync squid is back in sync', () => {
+      beforeEach(() => {
+        squidsMock.list = jest.fn().mockResolvedValue([mockSquids[3]])
+        desyncAlertLastSent.set('synchronized-squid-ETHEREUM-desync', Date.now())
+        desyncAlertLastSent.set('synchronized-squid-MATIC-desync', Date.now())
+      })
+
+      it('should clear the desync throttle state', async () => {
+        await monitorSquids()
+
+        expect(desyncAlertLastSent.size).toBe(0)
       })
     })
 

--- a/test/unit/squids-utils.spec.ts
+++ b/test/unit/squids-utils.spec.ts
@@ -1,4 +1,5 @@
-import { computeSyncProgress } from '../../src/ports/squids/utils'
+import { Network } from '@dcl/schemas'
+import { AVERAGE_BLOCK_TIME_SECONDS, computeSyncProgress, formatDuration, getBlocksBehind } from '../../src/ports/squids/utils'
 
 describe('computeSyncProgress', () => {
   describe('when the chain height is zero', () => {
@@ -34,6 +35,76 @@ describe('computeSyncProgress', () => {
   describe('when the last processed block is ahead of the chain height', () => {
     it('should cap the progress at 100', () => {
       expect(computeSyncProgress(1100, 1000)).toBe(100)
+    })
+  })
+})
+
+describe('getBlocksBehind', () => {
+  describe('when the last processed block is behind the chain height', () => {
+    it('should return the difference', () => {
+      expect(getBlocksBehind(88943857, 88945450)).toBe(1593)
+    })
+  })
+
+  describe('when the last processed block is at the chain height', () => {
+    it('should return 0', () => {
+      expect(getBlocksBehind(1000, 1000)).toBe(0)
+    })
+  })
+
+  describe('when the last processed block is ahead of a stale chain height', () => {
+    it('should clamp to 0 instead of going negative', () => {
+      expect(getBlocksBehind(1010, 1000)).toBe(0)
+    })
+  })
+})
+
+describe('formatDuration', () => {
+  describe('when the duration is non-positive', () => {
+    it('should return "0s"', () => {
+      expect(formatDuration(0)).toBe('0s')
+    })
+
+    describe('and the value is negative', () => {
+      it('should return "0s"', () => {
+        expect(formatDuration(-5)).toBe('0s')
+      })
+    })
+  })
+
+  describe('when the duration is under a minute', () => {
+    it('should return only seconds', () => {
+      expect(formatDuration(45)).toBe('45s')
+    })
+  })
+
+  describe('when the duration spans minutes and seconds', () => {
+    it('should return the two most significant units', () => {
+      expect(formatDuration(105)).toBe('1m 45s')
+    })
+  })
+
+  describe('when the duration spans hours and minutes', () => {
+    it('should return the two most significant units and drop the seconds', () => {
+      expect(formatDuration(4395.8)).toBe('1h 13m')
+    })
+  })
+
+  describe('when a unit in the middle is zero', () => {
+    it('should drop the zero unit instead of printing it', () => {
+      expect(formatDuration(3605)).toBe('1h')
+    })
+  })
+})
+
+describe('AVERAGE_BLOCK_TIME_SECONDS', () => {
+  describe('when used to estimate the time behind real-time', () => {
+    it('should use ~1.75s per block for Polygon', () => {
+      expect(AVERAGE_BLOCK_TIME_SECONDS[Network.MATIC]).toBe(1.75)
+    })
+
+    it('should use 12s per block for Ethereum', () => {
+      expect(AVERAGE_BLOCK_TIME_SECONDS[Network.ETHEREUM]).toBe(12)
     })
   })
 })


### PR DESCRIPTION
## Context

The "out of sync" Slack alert was sent on every monitor cycle (~60s), so a squid that stayed behind spammed the channel. It also reported the raw ETA in seconds with no sense of how far behind real-time the indexer actually was.

## Changes

- **Throttled the out-of-sync alert to once every 10 minutes** per squid + network (`desyncAlertLastSent` map, same pattern as the existing no-metrics throttle). The throttle is cleared as soon as the squid is back in sync, so a new desync alerts immediately.
- **Added "Blocks behind"** = `chain_height - last_block` (clamped to ≥ 0).
- **Added "Behind real-time"** = blocks behind × average block time, formatted human-readable (e.g. `~46m 27s (≈ 1.75s/block)`). Average block time per network lives in `AVERAGE_BLOCK_TIME_SECONDS` — Ethereum `12s`, Polygon `1.75s` (Polygon reduced its block time in May 2026; update the constant if it changes again).
- **Formatted the ETA** with the new `formatDuration` helper (`~1h 13m` instead of `4395.8 seconds`), and added thousands separators to the block numbers.
- **Prune stale throttle state**: entries for squids no longer active (e.g. after a blue/green deploy renames the service) are dropped each cycle, so the maps stay bounded. This also fixes the same latent growth in the pre-existing no-metrics map.

## Test plan

- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (41 passing — new specs for the 10-min throttle, resend-after-window, clear-on-recovery, prune, `getBlocksBehind`, `formatDuration`, and the block-lag fields in the alert)